### PR TITLE
example scripts to consume message queue and write to it

### DIFF
--- a/examples/kafka_consumer.py
+++ b/examples/kafka_consumer.py
@@ -1,0 +1,40 @@
+import os
+import logging
+import datetime
+from confluent_kafka import Consumer, KafkaError
+
+BOOTSTRAP_SERVERS = 'kafka-1.vmaas-ci.svc:29092'
+GROUP_ID = 'vulnerability' # The group ID for this service broker
+ENGINE_RESULTS_TOPIC = 'vulnerability_results'  # the topic to subscribe to for engine results
+
+logging.basicConfig(level=logging.INFO)
+logging.info("Using BOOTSTRAP_SERVERS: %s" % BOOTSTRAP_SERVERS)
+logging.info("Using GROUP_ID: %s" % GROUP_ID)
+logging.info("Using ENGINE_RESULTS_TOPIC: %s" % ENGINE_RESULTS_TOPIC)
+
+c = Consumer({
+        'bootstrap.servers': BOOTSTRAP_SERVERS,
+        'group.id': GROUP_ID,
+        'default.topic.config': {
+            'auto.offset.reset': 'smallest'
+        }
+    })
+
+topic_subscriptions = [ENGINE_RESULTS_TOPIC]
+c.subscribe(topic_subscriptions)
+
+while True:
+    msg = c.poll(1.0)
+
+    if msg is None:
+        continue
+    if msg.error():
+        if msg.error().code() == KafkaError._PARTITION_EOF:
+            continue
+        else:
+            logging.info(msg.error())
+
+    logging.info('Received Platform Kafka message at {} from topic {}: {}'.format(datetime.datetime.now(), msg.topic(), msg.value()))
+
+c.close()
+

--- a/examples/kafka_producer.py
+++ b/examples/kafka_producer.py
@@ -1,0 +1,29 @@
+import os
+import logging
+import datetime
+from confluent_kafka import Producer, KafkaError
+
+BOOTSTRAP_SERVERS = 'kafka-1.vmaas-ci.svc:29092'
+ENGINE_RESULTS_TOPIC = 'vulnerability_results'  # the topic to subscribe to for engine results'
+
+def produceMessageCallback(err, msg):
+    logging.info('Produce message callback err: %s' % (err))
+    logging.info('Produce message callback msg: %s' % (msg))
+    """ Called once for each message produced to indicate delivery result.
+        Triggered by poll() or flush(). """
+    if err is not None:
+        logging.info('Message delivery failed: {}'.format(err))
+    else:
+        logging.info('Message delivered to {} [{}]'.format(msg.topic(), msg.partition()))
+
+logging.basicConfig(level=logging.INFO)
+logging.info("Using BOOTSTRAP_SERVERS: %s" % BOOTSTRAP_SERVERS)
+logging.info("Using ENGINE_RESULTS_TOPIC: %s" % ENGINE_RESULTS_TOPIC)
+
+p = Producer({'bootstrap.servers': BOOTSTRAP_SERVERS})
+
+p.poll(0)
+p.produce(ENGINE_RESULTS_TOPIC,
+          "hello world",
+          callback=produceMessageCallback)
+p.flush()


### PR DESCRIPTION
- consumer and producer scripts for message queue running in remote `vmaas-ci` OpenShift project
- usage:
1.     $ oc login
2.     $ oc project vmaas-ci
3. forward kafka port from OpenShift pod to localhost:

       $ oc port-forward kafka-1-6-268rj 29092:29092

4. point `kafka-1.vmaas-ci.svc` hostname to `127.0.0.1` in your `/etc/hosts`
5. install dependency:

       $ pip install confluent-kafka

6. run listener:

       $ python examples/kafka_consumer.py

7. write to message queue

       $ python examples/kafka_producer.py