### PR TITLE
notify listener when all webapps are refreshed

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+COMPOSE_PROJECT_NAME=vulnerability

--- a/.gitignore
+++ b/.gitignore
@@ -78,9 +78,6 @@ celerybeat-schedule
 # SageMath parsed files
 *.sage.py
 
-# dotenv
-.env
-
 # virtualenv
 .venv
 venv/

--- a/docker-compose.devel.yml
+++ b/docker-compose.devel.yml
@@ -31,9 +31,6 @@ services:
       - label=disable
     working_dir: /git
     command: ["sleep", "infinity"]
-    networks:
-      - default
-      - vmaasgit_default
 
   ve_manager:
     volumes:
@@ -49,8 +46,3 @@ services:
     security_opt:
       - label=disable
     working_dir: /git
-
-networks:
-  default:
-  vmaasgit_default:
-    external: true

--- a/listener/reposcan_listener.py
+++ b/listener/reposcan_listener.py
@@ -58,14 +58,15 @@ class ServerApplication(Application):
             LOGGER.warning("Unable to connect to: %s", self.reposcan_websocket_url)
         else:
             LOGGER.info("Connected to: %s", self.reposcan_websocket_url)
+            result.write_message("subscribe-listener")
 
         self.reposcan_websocket = result
 
     def _read_websocket_message(self, message):
         """Read incoming websocket messages."""
         if message is not None:
-            if message == "refresh-cache":
-                LOGGER.warning("REPOSCAN REFRESHED CACHE !!!")
+            if message == "webapps-refreshed":
+                LOGGER.warning("ALL WEBAPPS REFRESHED CACHE !!!")
                 # TODO: write a message to the queue here
                 self.vuln_queue.send({"type": "vmaas_updates",
                                       "version":1,

--- a/listener/reposcan_listener.py
+++ b/listener/reposcan_listener.py
@@ -27,7 +27,7 @@ class ServerApplication(Application):
         Application.__init__(self, handlers)
         self.instance = IOLoop.instance()
         self.reposcan_websocket_url = os.getenv("REPOSCAN_WEBSOCKET_URL",
-                                                "ws://reposcan:8081/notifications")
+                                                "ws://vmaas_reposcan:8081/notifications")
         self.reposcan_websocket = None
         self.reconnect_callback = None
         self.vuln_queue = mqueue.QWriter()


### PR DESCRIPTION
- run vmaas and vuln-engine on same docker network
- identify webapp and listener connections and send confirmation to listener once all webapps are refreshed

see also https://github.com/RedHatInsights/vmaas/pull/409