### PR TITLE
add 3scale support

### DIFF
--- a/manager/common.py
+++ b/manager/common.py
@@ -4,10 +4,16 @@ import json
 import requests
 
 from tornado.web import RequestHandler
+import tornado
+import base64
+import json
+import logging
 
 VMAAS_URL = "https://webapp-vmaas-stage.1b13.insights.openshiftapps.com"
 DEFAULT_ROUTE = "/api/v1"
+IDENTITY_HEADER = "x-rh-identity"
 
+#logging.basicConfig(level=logging.DEBUG)
 
 class BaseHandler(RequestHandler):
 
@@ -21,6 +27,44 @@ class BaseHandler(RequestHandler):
     def options(self):
         self.set_status(204)
         self.finish()
+
+    def prepare(self):
+        logging.debug("Received request")
+        if 'x-rh-identity' not in self.request.headers:
+            self.send_error(403)
+            return
+
+        encoded_value = self.request.headers[IDENTITY_HEADER]
+        decoded_value = base64.b64decode(encoded_value).decode("utf-8")
+        logging.debug('identity decoded: %s' % decoded_value)
+        identity = json.loads(decoded_value)
+        if 'identity' in identity:
+            id_details = identity['identity']
+        else:
+            self.send_error(403)
+            return
+
+        if 'account_number' in id_details:
+            self.rh_account_number = id_details['account_number']
+            logging.debug('identity rh_account_number: %s' % self.rh_account_number)
+        else:
+            self.send_error(403)
+            return
+
+        if 'username' in id_details:
+            self.current_user = id_details['username']
+            logging.debug('identity username: %s' % self.current_user)
+        else:
+            self.send_error(403)
+            return
+
+        if 'locale' in id_details:
+            logging.debug('identity locale: %s' % id_details['locale'])
+            self.my_user_locale = tornado.locale.get(id_details['locale'])
+
+    def get_user_locale(self):
+        return self.my_user_locale
+
 
 
 def vmaas_call(endpoint, data):

--- a/manager/cve_handler.py
+++ b/manager/cve_handler.py
@@ -42,7 +42,7 @@ class CVEHandler(BaseHandler):
             FROM system_vulnerabilities v \
             JOIN system_platform s ON v.platform_id = s.platform_id \
             JOIN cve_metadata m ON v.cve = m.cve \
-            WHERE v.cve = %s", (synopsis,))
+            WHERE v.cve = %s AND s.rh_account = %s", (synopsis, self.rh_account_number))
         affected_systems = []
         for system in cur.fetchall():
             system_entry = {}

--- a/manager/vulnerabilities_handler.py
+++ b/manager/vulnerabilities_handler.py
@@ -11,6 +11,7 @@ class VulnerabilitiesHandler(BaseHandler):
     """Handler class returning data related to vulnerabilities."""
 
     def prepare(self):
+        super(VulnerabilitiesHandler, self).prepare()
         self.arguments = dict()
         for key in self.request.arguments.keys():
             self.arguments[key] = self.get_argument(key, None)
@@ -77,8 +78,10 @@ class VulnerabilitiesHandler(BaseHandler):
         cur.execute(
             "SELECT DISTINCT COUNT(sv.cve), sv.cve, vs.name \
             FROM system_vulnerabilities sv \
+            JOIN system_platform sp ON sv.platform_id = sp.platform_id \
             JOIN vulnerability_source vs ON sv.vulnerability_source = vs.id \
-            GROUP BY sv.cve, sv.vulnerability_source, vs.name"
+            WHERE sp.rh_account = %s \
+            GROUP BY sv.cve, sv.vulnerability_source, vs.name", (self.rh_account_number,)
         )
         cve_meta = cur.fetchall()
         cve_list = {"cve_list": [cve[1] for cve in cve_meta]}

--- a/scripts/3scale-mock
+++ b/scripts/3scale-mock
@@ -1,0 +1,123 @@
+#!/usr/bin/env python
+
+import os
+import sys
+import json
+import base64
+import argparse
+
+
+DEFAULT_IDENTITY_FILE = os.environ['HOME'] + "/.3scale-mock"
+DEFAULT_IDENTITY = """
+{
+  "identity" : { 
+    "id" : 1122334,
+    "org_id" : 3340851,
+    "account_number" : "00000000",
+    "username" : "jdoe@acme.com",
+    "email" : "jdoe@acme.com",
+    "first_name" : "john",
+    "last_name" : "doe",
+    "address_string": "\\"john doe\\" jdoe@acme.com",
+    "is_active" : true,
+    "is_org_admin" : false,
+    "is_internal" : false,
+    "locale" : "en_US"
+  }
+}
+"""
+
+debug = False
+
+def load_identity(filepath):
+    if os.path.isfile(filepath):
+        if debug:
+            print('Attempting to load identity from %s' % filepath)
+        with open(filepath, 'r') as identity_file:
+            return json.load(identity_file)
+    if filepath == DEFAULT_IDENTITY_FILE:
+        if debug:
+            print('Using default identity, no identity file %s' % filepath)
+        return json.loads(DEFAULT_IDENTITY)
+    return None
+
+def save_identity(identity, filepath):
+    if debug:
+        print('Saving identity to file %s' % filepath)
+    with open(filepath, 'w') as identity_file:
+        identity_file.write(json.dumps(identity))
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument('-f', '--file', dest='input_file',
+                        default=DEFAULT_IDENTITY_FILE,
+                        help='file containing identity to use [default: %s]' % DEFAULT_IDENTITY_FILE)
+    parser.add_argument('-i', '--id', type=int,
+                        help='id value to use in identity')
+    parser.add_argument('-o', '--org_id', type=int,
+                        help='ord_id to use in identity')
+    parser.add_argument('-a', '--account_number',
+                        help='rh account to use in identity')
+    parser.add_argument('-u', '--username',
+                        help='username to use in identity')
+    parser.add_argument('-d', '--debug', action='store_true',
+                        help='output additional information and details')
+    subparsers = parser.add_subparsers(help='commands', dest='command')
+    parser_save = subparsers.add_parser('save', help='save identity')
+    parser_save.add_argument('output_file', nargs='?',
+                             default=DEFAULT_IDENTITY_FILE,
+                             help='file to save [default: %s]' % DEFAULT_IDENTITY_FILE)
+
+    parser_print = subparsers.add_parser('print', help='print base64 encoded identity')
+
+    parser_curl = subparsers.add_parser('curl', help='issue curl command')
+
+    options, remaining = parser.parse_known_args()
+    if options.debug:
+        debug = True
+
+    identity = load_identity(options.input_file)
+    if not identity:
+        print('Unable to load identity from file %s' % options.input_file)
+        sys.exit(1)
+
+    if options.id:
+        identity['identity']['id'] = options.id
+    if options.org_id:
+        identity['identity']['org_id'] = options.org_id
+    if options.account_number:
+        identity['identity']['account_number'] = options.account_number
+    if options.username:
+        identity['identity']['username'] = options.username
+
+    if options.command == 'save':
+        if remaining:
+            print('Unexpected args %s' % remaining)
+            sys.exit(1)
+        save_identity(identity, options.output_file)
+        print('Identity saved to file %s' % options.output_file)
+        sys.exit(0)
+
+    encoded_identity = base64.b64encode(json.dumps(identity))
+
+    if options.command == 'print':
+        if remaining:
+            print('Unexpected args %s' % remaining)
+            sys.exit(1)        
+        print(encoded_identity)
+        sys.exit(0)
+
+    if options.command == 'curl':
+        if remaining:
+            args = remaining
+        else:
+            args = []
+        curl_command = 'curl'
+        curl_command += ' -H "x-rh-identity: %s"' % encoded_identity
+        curl_command += ' %s' % ' '.join('%s' % s if not True in [ c.isspace() for c in s ] else "'%s'" % s for s in args)
+
+        if debug:
+            print('Issuing the following curl command:')
+            print(curl_command)
+        os.system(curl_command)

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,39 @@
+# vulnerability-engine scripts
+
+Support scripts for vulnerability-engine project
+
+## 3scale-mock
+
+This is a command line tool for locally testing API calls. To use it, simply prefix the curl command you would use to hit the local system with the 3scale-mock script. For example:
+
+```./3scale-mock curl -k -X GET https://localhost:8300/api/v1/cves/CVE-2014-0160/affectedsystems/ | python -m json.tool```
+
+If ~/.3scale-mock exists, it will use it's contents for the identity it uses for the various commands. If it does not exist, it uses the identity defined in the 3scale-mock script itself.
+
+A few values in the identity can be overridden on the command line for easier testing.  3scale-mock help displays args that modify values in the identity.
+
+```./3scale-mock --help```
+
+3scale-mock supports 3 commands: 'curl', 'save' and 'print'
+
+```./3scale-mock [command] --help```
+
+### save
+
+Save the identity, modified by any 3scale-mock arguments that do so, to the optionally specified file, or the default ~/.3scale-mock
+
+The following command will load the default identity from ~/.3scale-mock, if it exists, or use the identity defined in the 3scale-mock script.  Then it will set the account number to '00000013' and the username to 'shadowman'.  Finally it will save the identity to ~/.3scale-mock.
+
+```./3scale-mock -a 00000013 -u shadowman save```
+
+### print
+
+Print the base64 encoded identity after its been modified by any 3scale-mock arguments that do so.
+
+### curl
+
+This executes a curl command, with the base64 encoded identity set in a header named 'x-rh-identity', followed by all arguments on the 3scale-mock command line that 3scale-mock does not itself recognize.
+
+Keep in mind, any args that 3scale-mock accepts cannot be passed to the curl command, but any other args not defined by 3scale-mock will get passed to the curl command.
+
+If you use the -d argument so that 3scale-mock prints out extra debug information, the output of the curl command will fail if piped to `python -m json.tool`


### PR DESCRIPTION
This adds 3scale support to manager. 

It also provides a 3scale-mock command line tool for locally testing.  To use it, simply prefix the curl command you would use to hit the local system with the 3scale-mock script.  For example:

./3scale-mock curl -k -X GET https://localhost:8300/api/v1/cves/CVE-2014-0160/affectedsystems/ | python -m json.tool

Run 3scale-mock --help for other options and commands ('curl' is a command, as is 'print' and 'save').
./3scale-mock save        <-- will write a default identity to ~/.3scale-mock

If ~/.3scale-mock exists, it will use it's contents for the identity sent to the server.  If not, it uses the identity defined in the 3scale-mock script itself.

A few values in the identity can be overridden on the command line for easier testing.  See 3scale-mock --help.

Keep in mind, any args that 3scale-mock accepts cannot be passed to the curl command, but any other args not defined by 3scale-mock will get passed to the curl command.

If you use the -d arg, the output of the curl command will fail if piped to `python -m json.tool`