### PR TITLE
create apidoc skeleton for future usage in manager

### DIFF
--- a/Dockerfile-apidoc
+++ b/Dockerfile-apidoc
@@ -1,0 +1,5 @@
+FROM swaggerapi/swagger-ui:v3.13.2
+
+RUN chmod g+w,o+w /etc/nginx/ /usr/share/nginx/html/ /var/log/nginx/ /run/nginx/ \
+    && chmod o+rx /var/lib/nginx/ \
+    && chmod g+rwx,o+rwx /var/lib/nginx/tmp/

--- a/Dockerfile-manager
+++ b/Dockerfile-manager
@@ -1,8 +1,8 @@
 FROM fedora:28
 
-RUN dnf -y update \
+RUN dnf -y update && dnf install -y dnf-plugins-core && dnf copr enable -y @vmaas/libs \
         && dnf -y install python3-tornado python3-psycopg2 \
-                          python3-requests postgresql \
+                          python3-requests postgresql python3-apispec \
         && rm -rf /var/cache/dnf/*
 
 ENV APPBASEDIR=/manager

--- a/conf/apidoc.env
+++ b/conf/apidoc.env
@@ -1,0 +1,1 @@
+API_URLS=[{url:'http://localhost:8300/r/insights/platform/vulnerability/v1/apispec', name:'vulnerability-engine-manager'}]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,5 +82,19 @@ services:
     ports:
       - 9092:9092
 
+  ve_apidoc:
+    container_name: vulnerability-engine-apidoc
+    build:
+      context: ./
+      dockerfile: ./Dockerfile-apidoc
+    image: vulnerability-engine/apidoc:latest
+    restart: unless-stopped
+    env_file:
+      - ./conf/apidoc.env
+    ports:
+      - 8000:8080
+    depends_on:
+      - ve_manager
+
 volumes:
   vulnerability-engine-db-data:

--- a/manager/common.py
+++ b/manager/common.py
@@ -33,6 +33,10 @@ class BaseHandler(RequestHandler):
         self.set_status(204)
         self.finish()
 
+    def get_user_locale(self):
+        return self.my_user_locale
+
+class AuthenticatedHandler(BaseHandler):
     def prepare(self):
         logging.debug("Received request")
         if 'x-rh-identity' not in self.request.headers:
@@ -67,10 +71,6 @@ class BaseHandler(RequestHandler):
         if 'locale' in id_details:
             logging.debug('identity locale: %s' % id_details['locale'])
             self.my_user_locale = tornado.locale.get(id_details['locale'])
-
-    def get_user_locale(self):
-        return self.my_user_locale
-
 
 def vmaas_call(endpoint, data):
     headers = {'Content-type': 'application/json',

--- a/manager/cve_handler.py
+++ b/manager/cve_handler.py
@@ -10,6 +10,13 @@ class CVEHandler(BaseHandler):
     """Handler class returning data related to given CVE."""
 
     def get(self):
+        """
+        ---
+        description: Get CVEs
+        responses:
+          200:
+            description: Handler class returning data related to given CVE.
+        """
         route = parse_url(self.request.uri, "/cves")
         if len(route) == 1:
             self.get_cve_details(route[0])

--- a/manager/cve_handler.py
+++ b/manager/cve_handler.py
@@ -2,11 +2,11 @@
 
 import json
 
-from common import BaseHandler, parse_url, vmaas_call
+from common import AuthenticatedHandler, parse_url, vmaas_call
 from database.database_handler import DatabaseHandler
 
 
-class CVEHandler(BaseHandler):
+class CVEHandler(AuthenticatedHandler):
     """Handler class returning data related to given CVE."""
 
     def get(self):

--- a/manager/main.py
+++ b/manager/main.py
@@ -3,20 +3,52 @@
 import os
 import sys
 
-from common import DEFAULT_ROUTE
+from apispec import APISpec
+from common import BaseHandler, DEFAULT_ROUTE
 from cve_handler import CVEHandler
 from database.database_handler import init_db
-from tornado import httpserver, ioloop, web
+from tornado import httpserver, ioloop, web, gen
 from vulnerabilities_handler import VulnerabilitiesHandler
 
+SPEC = APISpec(
+    title='Vulnerability Engine Manager',
+    version='latest',
+    plugins=(
+        'apispec.ext.tornado',
+    ),
+    basePath="/",
+)
+
+class ApiSpecHandler(BaseHandler):
+    """Handler class providing API specification."""
+
+    @gen.coroutine
+    def get(self): # pylint: disable=arguments-differ
+        """Get API specification.
+           ---
+           description: Get API specification
+           responses:
+             200:
+               description: OpenAPI/Swagger 2.0 specification JSON returned
+        """
+        result = SPEC.to_dict()
+        self.write(result)
+        yield self.flush()
+
+def setup_apispec(handlers):
+    for handler in handlers:
+        SPEC.add_path(urlspec=handler)
 
 class ServerApplication(web.Application):
     def __init__(self):
         handlers = [
+            (DEFAULT_ROUTE + r"/apispec/?", ApiSpecHandler),
             (DEFAULT_ROUTE + r"/cves/CVE-[^/]*/?[^/]*/?$", CVEHandler),
             (DEFAULT_ROUTE + r"/vulnerabilities/.*", VulnerabilitiesHandler)
         ]
         web.Application.__init__(self, handlers, autoreload=False, debug=False, serve_traceback=False)
+
+        setup_apispec(handlers)
 
 
 def main():

--- a/manager/vulnerabilities_handler.py
+++ b/manager/vulnerabilities_handler.py
@@ -3,11 +3,11 @@
 import json
 from random import randint
 
-from common import BaseHandler, parse_url, vmaas_call
+from common import AuthenticatedHandler, parse_url, vmaas_call
 from database.database_handler import DatabaseHandler
 
 
-class VulnerabilitiesHandler(BaseHandler):
+class VulnerabilitiesHandler(AuthenticatedHandler):
     """Handler class returning data related to vulnerabilities."""
 
     def prepare(self):

--- a/manager/vulnerabilities_handler.py
+++ b/manager/vulnerabilities_handler.py
@@ -17,6 +17,13 @@ class VulnerabilitiesHandler(BaseHandler):
             self.arguments[key] = self.get_argument(key, None)
 
     def get(self):
+        """
+        ---
+        description: Get Vulnerabilities
+        responses:
+          200:
+            description: Handler class returning data related to vulnerabilities.
+        """
         route = parse_url(self.request.uri, "/vulnerabilities")
         if len(route) == 1:
             if route[0] == "impacts":


### PR DESCRIPTION
This PR creates Swagger UI container for vulnerability-engine-manager APIs. As these are to be rewritten (pagination, filtering) it would be nice to have swagger already in place as this will happen.