### PR TITLE
add helper script to copy data from git into openshift container

### DIFF
--- a/scripts/openshift-rsync.sh
+++ b/scripts/openshift-rsync.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/bash
+
+case $1 in
+  evaluator|listener|manager)
+    dir=$1
+    shift
+    pod=$(oc get pods | grep $dir | grep Running | awk '{print $1}')
+    oc rsync $@ $dir/ $pod:$dir/ 
+  ;;
+  *)
+    echo "Usage: $0 evaluator|listener|manager [-h|-w|-q|...]"
+  ;;
+esac


### PR DESCRIPTION
Requires OpenShift container in devel mode (`./scripts/openshift-devel-container.sh`).

Examples:

Copy evaluator dir from git to OpenShift container and finish:
```
$ ./scripts/openshift-rsync.sh evaluator
```

Continuously keep OpenShift container synced with changes in git:
```
$ ./scripts/openshift-rsync.sh evaluator -w
```