### PR TITLE
workaround to quote more strings

### DIFF
--- a/scripts/3scale-mock
+++ b/scripts/3scale-mock
@@ -115,7 +115,7 @@ if __name__ == "__main__":
             args = []
         curl_command = 'curl'
         curl_command += ' -H "x-rh-identity: %s"' % encoded_identity
-        curl_command += ' %s' % ' '.join('%s' % s if not True in [ c.isspace() for c in s ] else "'%s'" % s for s in args)
+        curl_command += ' %s' % ' '.join('%s' % s if not True in [ c.isspace() or c == ';' for c in s ] else "'%s'" % s for s in args)
 
         if debug:
             print('Issuing the following curl command:')


### PR DESCRIPTION
this is needed for example when uploading new archive:

./3scale-mock curl -k -F "upload=@insights-ibm-x3650m4-03-vm04.lab.eng.brq.redhat.com-20181108112209-6.9.tar.gz;type=application/vnd.redhat.vulnerability.something+tgz" -H 'x-rh-insights-request-id: 52df9f748eabcfea' https://upload-service-vulnerability.192.168.42.14.nip.io/api/v1/upload