### PR TITLE
fix counting of vulnerable systems with different sources

### DIFF
--- a/manager/vulnerabilities_handler.py
+++ b/manager/vulnerabilities_handler.py
@@ -101,7 +101,7 @@ class VulnerabilitiesHandler(AuthenticatedHandler):
         result = []
         self.conn = DatabaseHandler.get_connection()
         cur = self.conn.cursor()
-        cur.execute("""SELECT DISTINCT COUNT(sv.cve), sv.cve, min(vs.name) AS name, md.cvss3_score, md.impact,
+        cur.execute("""SELECT COUNT(sv.cve), sv.cve, min(vs.name) AS name, md.cvss3_score, md.impact,
                             md.public_date, md.description
                     FROM system_vulnerabilities sv
                     JOIN system_platform sp ON sv.platform_id = sp.platform_id

--- a/manager/vulnerabilities_handler.py
+++ b/manager/vulnerabilities_handler.py
@@ -101,14 +101,14 @@ class VulnerabilitiesHandler(AuthenticatedHandler):
         result = []
         self.conn = DatabaseHandler.get_connection()
         cur = self.conn.cursor()
-        cur.execute("""SELECT DISTINCT COUNT(sv.cve), sv.cve, vs.name, md.cvss3_score, md.impact,
+        cur.execute("""SELECT DISTINCT COUNT(sv.cve), sv.cve, min(vs.name) AS name, md.cvss3_score, md.impact,
                             md.public_date, md.description
                     FROM system_vulnerabilities sv
                     JOIN system_platform sp ON sv.platform_id = sp.platform_id
                     JOIN vulnerability_source vs ON sv.vulnerability_source = vs.id
                     JOIN cve_metadata md ON sv.cve = md.cve
                     WHERE sp.rh_account = %s
-                    GROUP BY sv.cve, sv.vulnerability_source, vs.name, md.cvss3_score, md.impact,
+                    GROUP BY sv.cve, md.cvss3_score, md.impact,
                             md.public_date, md.description""", (self.rh_account_number,)
         )
         cve_meta = cur.fetchall()


### PR DESCRIPTION
When multiple systems have different sources of vulnerabilities the counting breaks like this due to way how the data is grouped. E.g.:
 count |      cve      |  name  | cvss3_score |  impact   |      public_date       
-------+---------------+-------+-------------+-----------+------------------------
     1 | CVE-2016-0800 | RULES |       5.900 | Important | 2016-03-01 00:00:00+00
     6 | CVE-2016-0800 | VMAAS |       5.900 | Important | 2016-03-01 00:00:00+00
If any of the for same cve has source RULES, then they should take precedence in the source and the counts should be added together.
E.g. like this:
 count |      cve      |  name  | cvss3_score |  impact   |      public_date       
-------+---------------+-------+-------------+-----------+------------------------
     7 | CVE-2016-0800 | RULES |       5.900 | Important | 2016-03-01 00:00:00+00
