### PR TITLE
fix#60 - set headers to comply with JSON:API specification

### DIFF
--- a/manager/common.py
+++ b/manager/common.py
@@ -34,6 +34,7 @@ class BaseHandler(RequestHandler):
                         "Content-Type, Access-Control-Allow-Headers, \
                         Authorization, X-Requested-With")
         self.set_header('Access-Control-Allow-Methods', 'POST, GET, OPTIONS')
+        self.set_header("Content-Type", "application/vnd.api+json")
 
     def options(self):
         self.set_status(204)


### PR DESCRIPTION
https://jsonapi.org/format/#content-negotiation-servers
Servers MUST send all JSON:API data in response documents with the header Content-Type: application/vnd.api+json without any media type parameters.