### PR TITLE
Fix #73 - wait for PostgreSQL in services depending on it

### DIFF
--- a/Dockerfile-evaluator
+++ b/Dockerfile-evaluator
@@ -1,13 +1,14 @@
 FROM fedora:28
 
 RUN dnf -y update \
-        && dnf -y install python3-kafka python3-requests python3-psycopg2 \
+        && dnf -y install python3-kafka python3-requests python3-psycopg2 postgresql \
         && rm -rf /var/cache/dnf/*
 
 ENV APPBASEDIR=/evaluator
 
 ADD $APPBASEDIR $APPBASEDIR/
 ADD /database/*.py $APPBASEDIR/database/
+ADD wait-for-postgres.sh $APPBASEDIR
 
 RUN adduser --gid 0 -d $APPBASEDIR --no-create-home -c 'Red Hat Insights' insights
 USER insights

--- a/Dockerfile-manager
+++ b/Dockerfile-manager
@@ -11,6 +11,7 @@ ENV APPBASEDIR=/manager
 ADD $APPBASEDIR/entrypoint.sh $APPBASEDIR/
 ADD $APPBASEDIR/*.py $APPBASEDIR/
 ADD /database/*.py $APPBASEDIR/database/
+ADD wait-for-postgres.sh $APPBASEDIR
 
 RUN adduser --gid 0 -d $APPBASEDIR --no-create-home -c 'Red Hat Insights' insights
 USER insights

--- a/evaluator/entrypoint.sh
+++ b/evaluator/entrypoint.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 DIR=$(dirname $0)
-exec $DIR/evaluator.py
+exec $DIR/wait-for-postgres.sh $DIR/evaluator.py

--- a/manager/entrypoint.sh
+++ b/manager/entrypoint.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 DIR=$(dirname $0)
-exec $DIR/main.py
+exec $DIR/wait-for-postgres.sh $DIR/main.py

--- a/wait-for-postgres.sh
+++ b/wait-for-postgres.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/bash
+
+set -e
+
+cmd="$@"
+
+until PGPASSWORD="$POSTGRESQL_PASSWORD" psql -h "$POSTGRESQL_HOST" -U "$POSTGRESQL_USER" -d "$POSTGRESQL_DATABASE" -c '\q' -q 2>/dev/null; do
+  >&2 echo "PostgreSQL is unavailable - sleeping"
+  sleep 1
+done
+
+>&2 echo "Everything is up - executing command"
+exec $cmd
+


### PR DESCRIPTION
Fixes issue where we are not waiting for start of PostgreSQL in some services which leads to following errors like:
vulnerability-engine-evaluator | Traceback (most recent call last):
vulnerability-engine-evaluator |   File "/evaluator/evaluator.py", line 337, in <module>
vulnerability-engine-evaluator |     main()
vulnerability-engine-evaluator |   File "/evaluator/evaluator.py", line 332, in main
vulnerability-engine-evaluator |     evaluator = QueueEvaluator(kafka_host, kafka_port, [kafka_evaluator_topic, kafka_rules_results_topic], kafka_group_id)
vulnerability-engine-evaluator |   File "/evaluator/evaluator.py", line 51, in __init__
vulnerability-engine-evaluator |     self.conn = DatabaseHandler.get_connection()
vulnerability-engine-evaluator |   File "/evaluator/database/database_handler.py", line 33, in get_connection
vulnerability-engine-evaluator |     database=cls.db_name, user=cls.db_user, password=cls.db_pass, host=cls.db_host, port=cls.db_port)
vulnerability-engine-evaluator |   File "/usr/lib64/python3.6/site-packages/psycopg2/__init__.py", line 130, in connect
vulnerability-engine-evaluator |     conn = _connect(dsn, connection_factory=connection_factory, **kwasync)
vulnerability-engine-evaluator | psycopg2.OperationalError: could not connect to server: Connection refused
vulnerability-engine-evaluator | 	Is the server running on host "ve_database" (172.18.0.3) and accepting
vulnerability-engine-evaluator | 	TCP/IP connections on port 5432?
