### PR TITLE
Add CVSS2 data to db and model.

### DIFF
--- a/database/peewee_model.py
+++ b/database/peewee_model.py
@@ -62,6 +62,8 @@ class CveMetadata(BaseModel):
     impact_id = ForeignKeyField(db_column="impact_id", rel_model=CveImpact, to_field="id") # pylint: disable=no-value-for-parameter
     public_date = DateTimeField(null=False)
     modified_date = DateTimeField(null=False)
+    cvss2_score = DecimalField(index=True, null=True)
+    cvss2_metrics = TextField(null=True)
 
     class Meta:
         """cve_metadata table metadata"""

--- a/database/ve_db_postgresql.sql
+++ b/database/ve_db_postgresql.sql
@@ -7,7 +7,7 @@
 -- The goal is to have one user per Vulnerability Engine component, and
 -- that user should be the only user allowed to write to tables for which
 -- the component is responsible.  In the bottom section, read access is
--- granted on all tables to all users.  
+-- granted on all tables to all users.
 --
 -- NOTE: If a table uses a sequence, make sure to grant USAGE, SELECT, UPDATE
 -- on the sequence to the user.  SERIAL and BIGSERIAL are create table time
@@ -142,6 +142,8 @@ CREATE TABLE IF NOT EXISTS cve_metadata (
   modified_date TIMESTAMP WITH TIME ZONE NULL,
   cvss3_score NUMERIC(5,3),
   cvss3_metrics TEXT,
+  cvss2_score NUMERIC(5,3),
+  cvss2_metrics TEXT,
   PRIMARY KEY (cve),
   CONSTRAINT impact_id
     FOREIGN KEY (impact_id)
@@ -150,6 +152,7 @@ CREATE TABLE IF NOT EXISTS cve_metadata (
 
 CREATE INDEX ON cve_metadata(impact_id);
 CREATE INDEX ON cve_metadata(cvss3_score);
+CREATE INDEX ON cve_metadata(cvss2_score);
 
 GRANT SELECT, INSERT, UPDATE, DELETE ON cve_metadata TO ve_db_user_evaluator;
 

--- a/evaluator/evaluator.py
+++ b/evaluator/evaluator.py
@@ -94,7 +94,7 @@ class QueueEvaluator:
             if new_cves:
                 # JSON to POST requests to vmaas CVEs endpoint
                 cves_json = {'cve_list': list(new_cves)}
-                cve_cvss3_list = []
+                cve_cvss_list = []
                 cve_system_list = []
 
                 response = requests.post(self.vmaas_cves_endpoint, json=cves_json)
@@ -112,17 +112,21 @@ class QueueEvaluator:
                         if cve not in cves_in_db:
                             # need also add a new CVE metadata into DB
                             cvss3_score = float(cves_response_json['cve_list'][cve]['cvss3_score'])
-                            cve_cvss3_list.append((cve, cvss3_score))
+                            if 'cvss2_score' in cves_response_json['cve_list'][cve]:
+                                cvss2_score = float(cves_response_json['cve_list'][cve]['cvss2_score'])
+                            else:
+                                cvss2_score = ''
+                            cve_cvss_list.append((cve, cvss3_score, cvss2_score))
 
                         cve_system_list.append((system_id, cve, source_id))
 
                     # Insert new CVEs into db
-                    if cve_cvss3_list:
-                        execute_values(cur, "insert into cve_metadata (cve, cvss3_score) values %s",
-                                       cve_cvss3_list, page_size=len(cve_cvss3_list))
+                    if cve_cvss_list:
+                        execute_values(cur, "insert into cve_metadata (cve, cvss3_score, cvss2_score) values %s",
+                                       cve_cvss_list, page_size=len(cve_cvss_list))
 
                     execute_values(cur, "insert into system_vulnerabilities \
-                                   (platform_id, cve, vulnerability_source) values %s",
+                                    (platform_id, cve, vulnerability_source) values %s",
                                    cve_system_list, page_size=len(cve_system_list))
 
                 else:
@@ -162,23 +166,31 @@ class QueueEvaluator:
                 modified_date = cves[cve]['modified_date'] or None
                 cvss3_score = float(cves[cve]['cvss3_score']) if cves[cve]['cvss3_score'] else None
                 cvss3_metrics = cves[cve]['cvss3_metrics']
-                row = (cve, description, impact_id, public_date, modified_date, cvss3_score, cvss3_metrics)
+                cvss2_score = float(cves[cve]['cvss2_score']) if 'cvss2_score' in cves[cve] else None
+                cvss2_metrics = cves[cve]['cvss2_metrics'] if 'cvss2_metrics' in cves[cve] else None
+                row = (cve, description, impact_id, public_date, modified_date, cvss3_score, cvss3_metrics,
+                       cvss2_score, cvss2_metrics)
                 if cve not in cves_in_db:
                     to_insert.append(row)
                 else:
                     to_update.append(row)
             if to_insert:
                 execute_values(cur, """insert into cve_metadata
-                                    (cve, description, impact_id, public_date, modified_date, cvss3_score, cvss3_metrics)
+                                    (cve, description, impact_id, public_date, modified_date,
+                                    cvss3_score, cvss3_metrics, cvss2_score, cvss2_metrics)
                                     values %s""", to_insert, page_size=len(to_insert))
             if to_update:
                 execute_values(cur, """update cve_metadata set description = data.description,
                                impact_id = data.impact_id,
                                public_date = cast(data.public_date as timestamp with time zone),
                                modified_date = cast(data.modified_date as timestamp with time zone),
-                               cvss3_score = cast(data.cvss3_score as numeric), cvss3_metrics = data.cvss3_metrics
+                               cvss3_score = cast(data.cvss3_score as numeric),
+                               cvss3_metrics = data.cvss3_metrics,
+                               cvss2_score = cast(data.cvss2_score as numeric),
+                               cvss2_metrics = data.cvss2_metrics
                                from (values %s) as data (cve, description, impact_id, public_date, modified_date,
-                               cvss3_score, cvss3_metrics) where cve_metadata.cve = data.cve""",
+                               cvss3_score, cvss3_metrics, cvss2_score, cvss2_metrics)
+                               where cve_metadata.cve = data.cve""",
                                to_update, page_size=len(to_update))
             if page >= r_json['pages']:
                 break

--- a/manager/system_handler.py
+++ b/manager/system_handler.py
@@ -15,6 +15,7 @@ class SystemCvesView(ListView):
             SystemVulnerabilities
             .select(CveMetadata.cve.alias('cve_name'),
                     CveMetadata.cvss3_score,
+                    CveMetadata.cvss2_score,
                     CveImpact.name.alias('impact'),
                     CveMetadata.public_date,
                     CveMetadata.description.alias('cve_description'))
@@ -28,7 +29,8 @@ class SystemCvesView(ListView):
         sortable_columns = {
             'cve' : SystemVulnerabilities.cve,
             'public_date' : CveMetadata.public_date,
-            'cvss_score' : CveMetadata.cvss3_score,
+            # This assumes we only show one score, and that cvss3 wins over cvss2
+            'cvss_score' : CveMetadata.cvss3_score if CveMetadata.cvss3_score else CveMetadata.cvss2_score,
             'impact' : CveMetadata.impact_id
         }
         filterable_columns = {
@@ -74,7 +76,17 @@ class SystemHandler(AuthenticatedHandler):
             record['public_date'] = cve['public_date'].isoformat()
             record['impact'] = cve['impact']
             record['description'] = cve['cve_description']
-            record['cvss_score'] = str(cve['cvss3_score']) if cve['cvss3_score'] is not None else ''
+            # Store everything we know about CVSS - maybe UI needs to decide what to show
+            record['cvss2_score'] = str(cve['cvss2_score']) if cve['cvss2_score'] is not None else ''
+            record['cvss3_score'] = str(cve['cvss3_score']) if cve['cvss3_score'] is not None else ''
+            # cvss_score might be cvss3, or 2, or empty, because CVE-data is filthy
+            if cve["cvss3_score"]:
+                record["cvss_score"] = str(cve["cvss3_score"])
+            elif cve["cvss2_score"]:
+                record["cvss_score"] = str(cve["cvss2_score"])
+            else:
+                record["cvss_score"] = ''
+
             result.append({'type' : 'cve', 'id' : cve['cve_name'], 'attributes' : record})
         try:
             response['meta'] = cves_view.get_metadata()

--- a/manager/vulnerabilities_handler.py
+++ b/manager/vulnerabilities_handler.py
@@ -26,14 +26,15 @@ class CvesListView(ListView):
                     CveMetadata.cve.alias("cve_name"),
                     fn.Min(VulnerabilitySource.name).alias("source_name"),
                     CveMetadata.cvss3_score,
-                    CveMetadata.impact_id,
+                    CveMetadata.cvss2_score,
+                    CveImpact.name.alias("impact"),
                     CveMetadata.public_date,
                     CveMetadata.description.alias("cve_description"))
             .join(SystemPlatform, on=((SystemVulnerabilities.platform_id == SystemPlatform.platform_id)
                                       & (SystemPlatform.rh_account == query_args["rh_account_number"])))
             .join(VulnerabilitySource, on=(SystemVulnerabilities.vulnerability_source == VulnerabilitySource.id))
             .join(CveMetadata, join_type, on=(SystemVulnerabilities.cve == CveMetadata.cve))
-            .group_by(CveMetadata.cve, CveMetadata.cvss3_score, CveMetadata.impact_id,
+            .group_by(CveMetadata.cve, CveMetadata.cvss3_score, CveMetadata.cvss2_score, CveImpact.impact_id,
                       CveMetadata.public_date, CveMetadata.description)
         )
         if 'cvss_from' in args and args['cvss_from']:
@@ -50,7 +51,8 @@ class CvesListView(ListView):
             "synopsis": CveMetadata.cve,
             "celebrity": VulnerabilitySource.name,
             "public_date": CveMetadata.public_date,
-            "cvss_score": CveMetadata.cvss3_score,
+            # This assumes we only show one score, and that cvss3 wins over cvss2
+            "cvss_score": CveMetadata.cvss3_score if CveMetadata.cvss3_score else CveMetadata.cvss2_score,
             "impact": CveMetadata.impact_id
         }
         filterable_columns = {
@@ -211,7 +213,16 @@ class VulnerabilitiesHandler(AuthenticatedHandler):
             entry["public_date"] = row["public_date"].isoformat()
             entry["impact"] = impact_id_map[row["impact_id"]]
             entry["description"] = row["cve_description"]
-            entry["cvss_score"] = str(row["cvss3_score"]) if row["cvss3_score"] is not None else ''
+            # Store everything we know about CVSS - maybe UI needs to decide what to show
+            entry["cvss2_score"] = str(row["cvss2_score"]) if row['cvss2_score'] is not None else ''
+            entry["cvss3_score"] = str(row["cvss3_score"]) if row['cvss3_score'] is not None else ''
+            # cvss_score might be cvss3, or 2, or empty, because CVE-data is filthy
+            if row["cvss3_score"]:
+                entry["cvss_score"] = str(row["cvss3_score"])
+            elif row["cvss2_score"]:
+                entry["cvss_score"] = str(row["cvss2_score"])
+            else:
+                entry["cvss_score"] = ''
             res["type"] = "cve"
             res["id"] = row["cve_name"]
             res["attributes"] = entry


### PR DESCRIPTION
Teach evaluator() that vmaas might return cvss2 data, and to store it
Teach SystemHandler and VulnerabilitiesHandler that both cvss2 and cvss3 exist
Teach SystemHandler and VulnerabilitiesHandler to use cvss2 for cvss_score IFF cvss3_score is empty

NOTE: The handlers now fill in cvss_score, cvss3_score, and cvss2_score. We may want the UI to decide what to show, in which case the UI should ignore cvss_score and use cvss2|3_score directly

NOTE 2: relies on a vmaas that has PR#433 merged, to provide cvss2 data