### PR TITLE
remove db_dev_data from schema initialization script

### DIFF
--- a/database/init_schema.sh
+++ b/database/init_schema.sh
@@ -4,11 +4,6 @@ if $PG_INITIALIZED ; then
     psql -d ${POSTGRESQL_DATABASE} -f ${CONTAINER_SCRIPTS_PATH}/start/ve_db_user_create_postgresql.sql
     psql -U ${POSTGRESQL_USER} -d ${POSTGRESQL_DATABASE} -f ${CONTAINER_SCRIPTS_PATH}/start/ve_db_postgresql.sql
 
-    # temp section to load dev data
-    if [ -f ${CONTAINER_SCRIPTS_PATH}/start/ve_db_dev_data.sql ] ; then
-        psql -U ${POSTGRESQL_USER} -d ${POSTGRESQL_DATABASE} -f ${CONTAINER_SCRIPTS_PATH}/start/ve_db_dev_data.sql
-    fi
-
     psql -c "ALTER USER ve_db_user_manager WITH PASSWORD '${VE_DB_USER_MANAGER_PASSWORD}'" -d ${POSTGRESQL_DATABASE}
     psql -c "ALTER USER ve_db_user_evaluator WITH PASSWORD '${VE_DB_USER_EVALUATOR_PASSWORD}'" -d ${POSTGRESQL_DATABASE}
     psql -c "ALTER USER ve_db_user_listener WITH PASSWORD '${VE_DB_USER_LISTENER_PASSWORD}'" -d ${POSTGRESQL_DATABASE}


### PR DESCRIPTION
not needed anymore due to changes in bb879759a31da1bb5745cf813e490e5efffef5de