### PR TITLE
fix import of cvss2_score and cvss2_metrics

### DIFF
--- a/evaluator/evaluator.py
+++ b/evaluator/evaluator.py
@@ -167,8 +167,8 @@ class QueueEvaluator:
                 modified_date = cves[cve]['modified_date'] or None
                 cvss3_score = float(cves[cve]['cvss3_score']) if cves[cve]['cvss3_score'] else None
                 cvss3_metrics = cves[cve]['cvss3_metrics']
-                cvss2_score = float(cves[cve]['cvss2_score']) if 'cvss2_score' in cves[cve] else None
-                cvss2_metrics = cves[cve]['cvss2_metrics'] if 'cvss2_metrics' in cves[cve] else None
+                cvss2_score = float(cves[cve]['cvss2_score']) if cves[cve]['cvss2_score'] else None
+                cvss2_metrics = cves[cve]['cvss2_metrics']
                 row = (cve, description, impact_id, public_date, modified_date, cvss3_score, cvss3_metrics,
                        cvss2_score, cvss2_metrics)
                 if cve not in cves_in_db:


### PR DESCRIPTION
Fixes following error during cve_metadata import

vulnerability-engine-evaluator | Traceback (most recent call last):
vulnerability-engine-evaluator |   File "/evaluator/evaluator.py", line 373, in <module>
vulnerability-engine-evaluator |     main()
vulnerability-engine-evaluator |   File "/evaluator/evaluator.py", line 369, in main
vulnerability-engine-evaluator |     evaluator.run()
vulnerability-engine-evaluator |   File "/evaluator/evaluator.py", line 327, in run
vulnerability-engine-evaluator |     self._sync_cve_md()
vulnerability-engine-evaluator |   File "/evaluator/evaluator.py", line 174, in _sync_cve_md
vulnerability-engine-evaluator |     cvss2_score = float(cves[cve]['cvss2_score']) if 'cvss2_score' in cves[cve] else None
vulnerability-engine-evaluator | ValueError: could not convert string to float: