### PR TITLE
sync Red Hat issued CVEs only

### DIFF
--- a/evaluator/evaluator.py
+++ b/evaluator/evaluator.py
@@ -150,7 +150,7 @@ class QueueEvaluator:
             for cve_tuple in cur.fetchall():
                 cves_in_db.append(cve_tuple[0])
         while True:
-            cve_list = {'cve_list' : [".*"], 'page_size' : page_size, 'page': page}
+            cve_list = {'cve_list' : [".*"], 'page_size' : page_size, 'page': page, 'rh_only' : True}
             response = requests.post(vmaas_cves_endpoint, json=cve_list)
             if response.status_code != 200:
                 break

--- a/evaluator/evaluator.py
+++ b/evaluator/evaluator.py
@@ -142,7 +142,7 @@ class QueueEvaluator:
         cur.close()
         self.conn.commit()
 
-    def _sync_cve_md(self, page_size=200, page=1, cves_in_db=None):
+    def _sync_cve_md(self, page_size=5000, page=1, cves_in_db=None):
         cur = self.conn.cursor()
         if not cves_in_db:
             cur.execute('select cve from cve_metadata')


### PR DESCRIPTION
Support for syncing only CVEs issued by Red Hat has been merged in VMAAS (https://github.com/RedHatInsights/vmaas/pull/437), use that functionality to sync rh cves only.
When rh_only is passed to older instances of vmaas they ignore it and do not crash.