### PR TITLE
don't return mishmash of cvss scores

### DIFF
--- a/manager/system_handler.py
+++ b/manager/system_handler.py
@@ -121,13 +121,6 @@ class SystemHandler(AuthenticatedHandler):
             # Store everything we know about CVSS - maybe UI needs to decide what to show
             record['cvss2_score'] = str(cve['cvss2_score']) if cve['cvss2_score'] is not None else ''
             record['cvss3_score'] = str(cve['cvss3_score']) if cve['cvss3_score'] is not None else ''
-            # cvss_score might be cvss3, or 2, or empty, because CVE-data is filthy
-            if cve["cvss3_score"]:
-                record["cvss_score"] = str(cve["cvss3_score"])
-            elif cve["cvss2_score"]:
-                record["cvss_score"] = str(cve["cvss2_score"])
-            else:
-                record["cvss_score"] = ''
 
             result.append({'type' : 'cve', 'id' : cve['cve_name'], 'attributes' : record})
         try:

--- a/manager/vulnerabilities_handler.py
+++ b/manager/vulnerabilities_handler.py
@@ -217,13 +217,6 @@ class VulnerabilitiesHandler(AuthenticatedHandler):
             # Store everything we know about CVSS - maybe UI needs to decide what to show
             entry["cvss2_score"] = str(row["cvss2_score"]) if row['cvss2_score'] is not None else ''
             entry["cvss3_score"] = str(row["cvss3_score"]) if row['cvss3_score'] is not None else ''
-            # cvss_score might be cvss3, or 2, or empty, because CVE-data is filthy
-            if row["cvss3_score"]:
-                entry["cvss_score"] = str(row["cvss3_score"])
-            elif row["cvss2_score"]:
-                entry["cvss_score"] = str(row["cvss2_score"])
-            else:
-                entry["cvss_score"] = ''
             res["type"] = "cve"
             res["id"] = row["cve_name"]
             res["attributes"] = entry


### PR DESCRIPTION
in the cvss_score field we sometimes return cvss3_score if it's available and sometimes cvss2 if v3 is not available, as there's no simple indicator (apart from looking whether cvss3_score is null or not) like field which version is returned
as we return both cvss2_score and cvss3_score the 'cvss_score' field is not needed as it returns mismash