### PR TITLE
fix query

### DIFF
--- a/evaluator/evaluator.py
+++ b/evaluator/evaluator.py
@@ -241,8 +241,8 @@ class QueueEvaluator:
         execute_values(cur, "update sys_vuln_rules_results set \
                                  details = data.details \
                              from (values %s) as data (sys_vuln_id, ek_id, details) \
-                             where sys_vuln_id = data.sys_vuln_id \
-                                 and error_key_id = data.ek_id",
+                             where sys_vuln_rules_results.sys_vuln_id = data.sys_vuln_id \
+                                 and sys_vuln_rules_results.error_key_id = data.ek_id",
                        rules_to_update, page_size=len(rules_to_update))
         cur.close()
         self.conn.commit()


### PR DESCRIPTION
Traceback (most recent call last):
  File "/evaluator/evaluator.py", line 549, in <module>
    main()
  File "/evaluator/evaluator.py", line 542, in main
    evaluator.run()
  File "/evaluator/evaluator.py", line 528, in run
    self.evaluate_rules(msg_dict)
  File "<decorator-gen-2>", line 2, in evaluate_rules
  File "/usr/local/lib/python3.6/site-packages/prometheus_client/context_managers.py", line 66, in wrapped
    return func(*args, **kwargs)
  File "/evaluator/evaluator.py", line 470, in evaluate_rules
    self._rules_update(rule_results_update)
  File "/evaluator/evaluator.py", line 246, in _rules_update
    rules_to_update, page_size=len(rules_to_update))
  File "/usr/lib64/python3.6/site-packages/psycopg2/extras.py", line 1274, in execute_values
    cur.execute(b.join(parts))
psycopg2.ProgrammingError: column reference "sys_vuln_id" is ambiguous
LINE 1: ...k_id, details) where sys_vuln_i...