### PR TITLE
remove obsolete container dependencies

### DIFF
--- a/Dockerfile-listener
+++ b/Dockerfile-listener
@@ -1,8 +1,6 @@
 FROM fedora:28
 
 RUN dnf -y update \
-        && dnf install -y dnf-plugins-core \
-        && dnf copr enable -y @vmaas/libs \
         && dnf -y install python3-tornado python3-psycopg2 \
                           python3-requests postgresql python3-pip \
         && pip3 install insights-core aiokafka \


### PR DESCRIPTION
as we're using insights-core from pip there's no need to install dnf plugins and enable @vmaas/libs