### PR TITLE
add support to get all rule details for a system

### DIFF
--- a/manager/rule_handler.py
+++ b/manager/rule_handler.py
@@ -25,13 +25,12 @@ class RuleHandler(AuthenticatedHandler):
         route = parse_url(self.request.uri, "/rules")
         if len(route) == 2 and route[1] == "affected_systems":
             self.get_affected_systems(route[0])
-        elif len(route) == 3:
-            if route[1] == "insights_id":
-                self.get_details_by_insights_id(route[0], route[2])
-            elif route[1] == "inventory_id":
-                self.get_details_by_inventory_id(route[0], route[2])
-            else:
-                self.raiseError(404)
+        elif len(route) == 2 and route[1] == "details":
+            self.get_system_rule_details(route[0])
+        elif len(route) == 3 and route[1] == "insights_id":
+            self.get_details_by_insights_id(route[0], route[2])
+        elif len(route) == 3 and route[1] == "inventory_id":
+            self.get_details_by_inventory_id(route[0], route[2])
         else:
             self.raiseError(404)
         self.flush()
@@ -67,6 +66,34 @@ class RuleHandler(AuthenticatedHandler):
             system_entry["rule_id"] = row["rule_id"]
             affected_systems.append(system_entry)
         self.write(json.dumps(affected_systems))
+
+    def get_system_rule_details(self, inventory_id):
+        """Get the rule results details for the specified
+           inventory_id"""
+        query = (
+            SysVulnRulesResults
+            .select(ProdsecRule.name.alias("rule_id"),
+                    SysVulnRulesResults.details)
+            .join(SystemVulnerabilities, on=(SysVulnRulesResults.sys_vuln_id == SystemVulnerabilities.id))
+            .join(SystemPlatform, on=(SystemVulnerabilities.insights_id == SystemPlatform.insights_id))
+            .join(ProdsecRule, on=(SysVulnRulesResults.prodsec_rule_id == ProdsecRule.id))
+            .where(SystemPlatform.rh_account == self.rh_account_number)
+            .where(SystemPlatform.inventory_id == inventory_id)
+            .dicts()
+        )
+        rule_ids = {}
+        if not query:
+            self.raiseError(404)
+            return
+        for row in query:
+            details = {}
+            if 'details' in row:
+                details = json.loads(row['details'])
+            rule_ids[row['rule_id']] = details
+        retval = {
+            'inventory_id': inventory_id,
+            'rule_ids': rule_ids}
+        self.write(json.dumps(retval))
 
     def get_details_by_insights_id(self, rule_id, insights_id):
         """Get the rule results details for the specified


### PR DESCRIPTION
Added new api call to get all rule details for a system.

I think the previous two calls can be removed, but I'll leave them in for now.

New api call is
/r/insights/platform/vulnerability/v1/rules/<inventory_id>/details

NOTE: this call requires inventory_id, not insights_id as used in most of our other api that require the system identifier.

Results look like this:
{
    "inventory_id": "fb0820e7-18c1-4a8c-a78a-901faef7fbe2",
    "rule_ids": {
        "CVE_2017_5715_cpu_virt|VIRT_CVE_2017_5715_CPU_3_ONLYKERNEL": {
            "affected_amd_family": false,
            "cves_fail": [
                "CVE-2017-5715"
            ],
            "cves_pass": [],
            "error_key": "VIRT_CVE_2017_5715_CPU_3_ONLYKERNEL",
            "kernel_pkg_name": "kernel",
            "type": "rule"
        },
        "CVE_2017_5753_4_cpu_kernel|KERNEL_CVE_2017_5753_4_CPU_ERROR_3": {
            "cves_fail": [
                "CVE-2017-5715"
            ],
            "cves_pass": [
                "CVE-2017-5753",
                "CVE-2017-5754"
            ],
            "debugfs_available": true,
            "dmesg_available": true,
            "dmesg_wrapped": false,
            "error_key": "KERNEL_CVE_2017_5753_4_CPU_ERROR_3",
            "mfr": "Intel",
            "old_specs_on_client": false,
            "package_name": "kernel",
            "problems": {
                "firmware_supports_features": false,
                "ibpb_cmdline_disabled": false,
                "ibpb_cmdline_spectre_v2_disabled": false,
                "ibrs_cmdline_disabled": false,
                "ibrs_cmdline_spectre_v2_disabled": false,
                "kernel_supports_features": true,
                "pti_cmdline_disabled": false,
                "rfi_flush_cmdline_disabled": false,
                "spectre_v2_disabling_cmdline": null,
                "v1_vulnerable": false,
                "v2_vulnerable": true,
                "v3_vulnerable": false
            },
            "release_major": "7",
            "retpo_kernel_but_no_sys_cpu_vuln": false,
            "running_kernel": "3.10.0-693.17.1.el7.x86_64",
            "sysfs_vuln_md": null,
            "sysfs_vuln_s1": null,
            "sysfs_vuln_s2": null,
            "type": "rule",
            "virtual": "qemu"
        },
        "CVE_2018_1111_dhcp|ERROR_CVE_2018_1111_DHCP_2": {
            "cves_fail": [
                "CVE-2018-1111"
            ],
            "cves_pass": [],
            "dhcp_devs": [
                "eth0"
            ],
            "error_key": "ERROR_CVE_2018_1111_DHCP_2",
            "release": 7,
            "svc_on": true,
            "type": "rule",
            "vuln_files": [
                "/etc/NetworkManager/dispatcher.d/11-dhclient"
            ]
        },
        "CVE_2018_3620_cpu_kernel|CVE_2018_3620_CPU_KERNEL_NEED_UPDATE": {
            "cmd": false,
            "cves_fail": [
                "CVE-2018-3620"
            ],
            "cves_pass": [],
            "error_key": "CVE_2018_3620_CPU_KERNEL_NEED_UPDATE",
            "firmware": false,
            "kernel": false,
            "rel": 7,
            "rt": false,
            "smt": false,
            "type": "rule",
            "vuln": null
        },
        "CVE_2018_3639_cpu_kernel|CVE_2018_3639_CPU_BAD_KERNEL": {
            "cmd_avail": true,
            "cmd_no_ssd": false,
            "cmd_ssbd_off": false,
            "cves_fail": [
                "CVE-2018-3639"
            ],
            "cves_pass": [],
            "error_key": "CVE_2018_3639_CPU_BAD_KERNEL",
            "rt": false,
            "running_kernel": "3.10.0-693.17.1.el7.x86_64",
            "type": "rule",
            "virtual": "qemu",
            "vuln_file_present": false
        },
        "CVE_2018_8897_kernel_popss|KERNEL_CVE_2018_8897_VULNERABLE_2": {
            "cves_fail": [
                "CVE-2018-8897",
                "CVE-2018-1087"
            ],
            "cves_pass": [],
            "error_key": "KERNEL_CVE_2018_8897_VULNERABLE_2",
            "kernel_version": "3.10.0-693.17.1.el7",
            "other_rpms": [],
            "package": "kernel",
            "type": "rule"
        },
        "httpd_poodle|HTTPD_POODLE_WARN_3": {
            "cves_fail": [
                "CVE-2014-3566"
            ],
            "cves_pass": [],
            "error_key": "HTTPD_POODLE_WARN_3",
            "nss_protocols": null,
            "scl_installed": false,
            "ssl_protocols": [
                [
                    "SSLProtocol all -SSLv2",
                    "/etc/httpd/conf.d/ssl.conf"
                ]
            ],
            "type": "rule"
        }
    }
}

