### PR TITLE
base listener on CentOS and RHEL

### DIFF
--- a/Dockerfile-listener
+++ b/Dockerfile-listener
@@ -1,10 +1,9 @@
-FROM fedora:28
+FROM centos:7
 
-RUN dnf -y update \
-        && dnf -y install python3-tornado python3-psycopg2 \
-                          python3-requests postgresql python3-pip \
-        && pip3 install insights-core aiokafka \
-        && rm -rf /var/cache/dnf/*
+RUN yum -y update \
+    && yum -y install centos-release-scl \
+    && yum -y install rh-python36 postgresql \
+    && rm -rf /var/cache/yum/* 
 
 ENV APPBASEDIR=/listener
 
@@ -12,10 +11,16 @@ ADD $APPBASEDIR/*.sh $APPBASEDIR/
 ADD $APPBASEDIR/*.py $APPBASEDIR/
 ADD $APPBASEDIR/common/*.py $APPBASEDIR/common/
 ADD /database/*.py $APPBASEDIR/database/
+ADD scl-enable.sh $APPBASEDIR/
 
 RUN adduser --gid 0 -d $APPBASEDIR --no-create-home -c 'Red Hat Insights' insights
+RUN chown -R insights $APPBASEDIR
+
+RUN $APPBASEDIR/scl-enable.sh pip install --upgrade pip
+# Install Python libs as user
 USER insights
+RUN $APPBASEDIR/scl-enable.sh pip install --user psycopg2-binary tornado requests insights-core aiokafka
 
 EXPOSE 8000
 
-CMD ["sh", "-c", "$APPBASEDIR/entrypoint.sh"]
+CMD ["sh", "-c", "$APPBASEDIR/scl-enable.sh $APPBASEDIR/entrypoint.sh"]

--- a/Dockerfile-listener.rhel7
+++ b/Dockerfile-listener.rhel7
@@ -1,0 +1,26 @@
+FROM registry.access.redhat.com/rhel7
+
+RUN yum -y update \
+    && yum-config-manager --enable rhel-server-rhscl-7-rpms \
+    && yum -y install rh-python36 postgresql \
+    && rm -rf /var/cache/yum/* 
+
+ENV APPBASEDIR=/listener
+
+ADD $APPBASEDIR/*.sh $APPBASEDIR/
+ADD $APPBASEDIR/*.py $APPBASEDIR/
+ADD $APPBASEDIR/common/*.py $APPBASEDIR/common/
+ADD /database/*.py $APPBASEDIR/database/
+ADD scl-enable.sh $APPBASEDIR/
+
+RUN adduser --gid 0 -d $APPBASEDIR --no-create-home -c 'Red Hat Insights' insights
+RUN chown -R insights $APPBASEDIR
+
+RUN $APPBASEDIR/scl-enable.sh pip install --upgrade pip
+# Install Python libs as user
+USER insights
+RUN $APPBASEDIR/scl-enable.sh pip install --user psycopg2-binary tornado requests insights-core aiokafka
+
+EXPOSE 8000
+
+CMD ["sh", "-c", "$APPBASEDIR/scl-enable.sh $APPBASEDIR/entrypoint.sh"]

--- a/listener/listener.py
+++ b/listener/listener.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """Main module for listener."""
 
 from multiprocessing import Process

--- a/scl-enable.sh
+++ b/scl-enable.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+cmd="$@"
+exec /usr/bin/scl enable rh-python36 "$cmd"


### PR DESCRIPTION
- using Python 3.6 from SCL
- both CentOS 7 and RHEL 7 Dockerfiles
- RHEL 7 Dockerfile requires Docker host/OpenShift platform with valid subscription

TODO:
- convert other services
- change e2e templates to build from RHEL Dockerfile on prod