### PR TITLE
Change to pip install as root so any user can access the libs

### DIFF
--- a/Dockerfile-listener
+++ b/Dockerfile-listener
@@ -17,9 +17,10 @@ RUN adduser --gid 0 -d $APPBASEDIR --no-create-home -c 'Red Hat Insights' insigh
 RUN chown -R insights $APPBASEDIR
 
 RUN $APPBASEDIR/scl-enable.sh pip install --upgrade pip
-# Install Python libs as user
+
+RUN $APPBASEDIR/scl-enable.sh pip install psycopg2-binary tornado requests insights-core aiokafka
+
 USER insights
-RUN $APPBASEDIR/scl-enable.sh pip install --user psycopg2-binary tornado requests insights-core aiokafka
 
 EXPOSE 8000
 

--- a/Dockerfile-listener.rhel7
+++ b/Dockerfile-listener.rhel7
@@ -17,9 +17,10 @@ RUN adduser --gid 0 -d $APPBASEDIR --no-create-home -c 'Red Hat Insights' insigh
 RUN chown -R insights $APPBASEDIR
 
 RUN $APPBASEDIR/scl-enable.sh pip install --upgrade pip
-# Install Python libs as user
+
+RUN $APPBASEDIR/scl-enable.sh pip install psycopg2-binary tornado requests insights-core aiokafka
+
 USER insights
-RUN $APPBASEDIR/scl-enable.sh pip install --user psycopg2-binary tornado requests insights-core aiokafka
 
 EXPOSE 8000
 


### PR DESCRIPTION
In dev environment, OpenShift default SCC causes pod to run as some random UID in a set range of UIDs.  It is overriding our attempt to run as user 'insights'.  We were installing the pip modules with "--user" arg, so other users weren't able to access the libs.  In minishift env, pod runs as user 'insights', so we didn't see the issue.

Dockerfiles are now changed to run pip install as root and without "--user" arg so all user have access to the installed libs.

This is part of VMAAS-225