### PR TITLE
VMAAS-270 : expose satellite_managed to the API

### DIFF
--- a/manager/cve_handler.py
+++ b/manager/cve_handler.py
@@ -15,6 +15,7 @@ class AffectedSystemsView(ListView):
         query = (
             SystemVulnerabilities
             .select(SystemPlatform.inventory_id,
+                    SystemPlatform.satellite_managed,
                     Status.id.alias('status_id'),
                     Status.name.alias('status_name'))
             .join(SystemPlatform, on=(SystemVulnerabilities.inventory_id == SystemPlatform.inventory_id))
@@ -97,6 +98,7 @@ class CVEHandler(AuthenticatedHandler):
             record['inventory_id'] = sys['inventory_id']
             record['status_id'] = sys['status_id']
             record['status_name'] = sys['status_name']
+            record['satellite_managed'] = sys['satellite_managed']
             result.append({'type' : 'system', 'id' : sys['inventory_id'], 'attributes' : record})
         response['meta'] = asys_view.get_metadata()
         response['data'] = self._format_data(list_arguments["data_format"], result)

--- a/manager/system_handler.py
+++ b/manager/system_handler.py
@@ -65,11 +65,12 @@ class SystemView(ListView):
         query = (
             SystemPlatform
             .select(SystemPlatform.inventory_id,
+                    SystemPlatform.satellite_managed,
                     fn.Count(SystemVulnerabilities.inventory_id).alias('cve_count'))
             .join(SystemVulnerabilities, JOIN.LEFT_OUTER,
                   on=(SystemPlatform.inventory_id == SystemVulnerabilities.inventory_id))
             .where(SystemPlatform.rh_account == query_args['rh_account_number'])
-            .group_by(SystemPlatform.inventory_id, SystemPlatform.inventory_id)
+            .group_by(SystemPlatform.inventory_id, SystemPlatform.satellite_managed)
             .dicts()
         )
         sortable_columns = {


### PR DESCRIPTION
Accessible from :
```
curl http://MACHINE:8300/r/insights/platform/vulnerability/v1/cves/CVE-2019-000666/affected_systems | python -m json.tool
{
    "meta": {...},
    "data": [
        {
            "type": "system",
            "id": "inventory-01",
            "attributes": {
                "inventory_id": "inventory-01",
                "status_id": 2,
                "status_name": "On-Hold",
                "satellite_managed": false
            }
        }
    ]
}
```

AND

```
curl http://MACHINE:8300/r/insights/platform/vulnerability/v1/systems | python -m json.tool
{
    "data": [
        {
            "attributes": {
                "inventory_id": "inventory-01",
                "satellite_managed": false,
                "cve_count": 1
            },
            "id": "inventory-01",
            "type": "system"
        }
    ],
    "meta": {...}
}
```