### PR TITLE
stop kicking off rules-engine processing

### DIFF
--- a/evaluator/evaluator.py
+++ b/evaluator/evaluator.py
@@ -509,7 +509,11 @@ class QueueEvaluator:
                                 (msg_dict['system_id'],))
                     system_platform = cur.fetchone()
                     if system_platform is not None:
-                        self.producer.send(self._prepare_rules_engine_request(msg_dict))
+                        # stop kicking off rules-engine processing to avoid
+                        # log messages about failure to find inventory_id
+                        # in db.  Rule-engine is sending back system_id, not
+                        # inventory_id.
+                        # self.producer.send(self._prepare_rules_engine_request(msg_dict))
                         self.evaluate_vmaas(system_platform)
                     else:
                         logging.error("System with inventory_id not found in DB: %s", msg_dict['system_id'])


### PR DESCRIPTION
This to prevent log messages about "can't find inventory_id in db" because rules-engine is sending back insights system id, not inventory_id.