### PR TITLE
pre-commit + Python 3 compatibility

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
   rev: 18.9b0
   hooks:
   - id: black
-    args: [--safe, --quiet, --line-length, "100"]
+    args: [--safe, --quiet, --line-length, "120"]
     language_version: python3
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v2.1.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,30 @@
+repos:
+- repo: https://github.com/asottile/reorder_python_imports
+  rev: v1.3.5
+  hooks:
+  - id: reorder-python-imports
+    language_version: python3
+- repo: https://github.com/ambv/black
+  rev: 18.9b0
+  hooks:
+  - id: black
+    args: [--safe, --quiet, --line-length, "100"]
+    language_version: python3
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v2.1.0
+  hooks:
+  - id: trailing-whitespace
+    language_version: python3
+  - id: end-of-file-fixer
+    language_version: python3
+  - id: check-yaml
+    language_version: python3
+  - id: debug-statements
+    language_version: python3
+  - id: flake8
+    language_version: python3
+- repo: https://github.com/asottile/pyupgrade
+  rev: v1.11.3
+  hooks:
+  - id: pyupgrade
+    language_version: python3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 apispec==0.39.0
 peewee
+pre-commit
 prometheus_client
 psycopg2
 pytest

--- a/scripts/github-fetch-pullrequest
+++ b/scripts/github-fetch-pullrequest
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Fetch pull requests from GitHub and prepare them for rebase process
 
 Usage:
@@ -10,8 +10,6 @@ Usage:
   * PROG <n> [--ignore-dirty | -i] -- fetch PR without checking local
         repository
 """
-
-from __future__ import print_function
 
 import git
 import os

--- a/scripts/github-fetch-pullrequest
+++ b/scripts/github-fetch-pullrequest
@@ -11,6 +11,8 @@ Usage:
         repository
 """
 
+from __future__ import print_function
+
 import git
 import os
 import re
@@ -31,8 +33,7 @@ class Progress(git.RemoteProgress):
         self.desc = desc
 
     def update(self, op_code, cur_count, max_count=None, message=''):
-        print "\r%s: %s/%s %s" % (self.desc, cur_count, max_count, message),
-        sys.stdout.flush()
+        print("\r{}: {}/{} {}".format(self.desc, cur_count, max_count, message), end="", flush=True)
 
 
 def setup_token():
@@ -50,7 +51,7 @@ def list_requests():
         url += "?access_token=%s" % OAUTH
     pull_requests = simplejson.load(urllib.urlopen(url))
     for request in pull_requests:
-        print request.get('number'), request.get('title')
+        print("{} {}".format(request.get('number'), request.get('title')))
 
 
 def get_pull_request(req_num):
@@ -65,7 +66,7 @@ def get_pull_request(req_num):
 def guess_USER_REPO():
     """Uses convention that upstream remote is named either
     'upstream' or 'origin'"""
-    a = dict((r.name, re.match('.*[:/](.*)/(.*)\.git', r.url).groups())
+    a = dict((r.name, re.match(r'.*[:/](.*)/(.*)\.git', r.url).groups())
         for r in repo.remotes)
     return a.get('upstream') or a.get('origin')
 
@@ -74,14 +75,14 @@ def prepare_repo(repo, req_num, master, ignore_dirty):
     """Main functionality"""
     if not ignore_dirty:
         if repo.is_dirty() or repo.untracked_files:
-            print "Repo is dirty (uncommited changes/untracked files)."
+            print("Repo is dirty (uncommited changes/untracked files).")
             sys.exit(1)
 
     pull_request = get_pull_request(req_num)
 
     message = pull_request.get("message")
     if message:
-        print message
+        print(message)
         sys.exit(2)
 
     remote_url = pull_request.get("head").get("repo").get("clone_url")
@@ -89,7 +90,7 @@ def prepare_repo(repo, req_num, master, ignore_dirty):
     remote_branch = pull_request.get("head").get("ref")
     local_branch = pull_request.get("base").get("ref")
 
-    print (remote_url, remote_branch)
+    print("{} {}".format(remote_url, remote_branch))
 
     remote_name = "pull-request-%s-%s" % (from_who, remote_branch)
 
@@ -103,15 +104,15 @@ def prepare_repo(repo, req_num, master, ignore_dirty):
     try:
         repo.git.rebase(local_branch)
     except git.exc.GitCommandError:
-        print ("Rebase failed. You can either resolve it and run "
-               "`git rebase --continue` or ask author to do the rebase.")
+        print("Rebase failed. You can either resolve it and run "
+              "`git rebase --continue` or ask author to do the rebase.")
 
     if master:
         repo.git.checkout("master")
         repo.git.merge(remote_name, "--ff-only")
         repo.git.branch("-d", remote_name)
 
-    print ("\nIn branch '%s'." % ("master" if master else remote_name))
+    print("\nIn branch '{}'.".format("master" if master else remote_name))
 
 if __name__ == "__main__":
     repo = git.Repo(search_parent_directories=True)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 120


### PR DESCRIPTION
Adds pre-commit config (and fixes Python 3 compatibility).

Once https://github.com/RedHatInsights/vulnerability-engine/pull/173 is merged I'll add `pre-commit` to `requirements.txt`.

Then it will be ready to run `pre-commit run --all-files`, create PR with all changes and merge it so everyone can start working on reformatted files without rebasing their code a lot.

Also will require fixing lot of issues found by flake8 (line length etc.)