### PR TITLE
VMAAS-314 - add 'last_evaluation' timestamp and don't display not evaluated systems

### DIFF
--- a/common/peewee_model.py
+++ b/common/peewee_model.py
@@ -38,6 +38,7 @@ class SystemPlatform(BaseModel):
     satellite_managed = BooleanField(null=False)
     last_updated = DateTimeField(null=False)
     unchanged_since = DateTimeField(null=False)
+    last_evaluation = DateTimeField(null=True)
 
     class Meta:
         """system_platform table metadata"""

--- a/database/ve_db_dev_data.sql
+++ b/database/ve_db_dev_data.sql
@@ -8,10 +8,12 @@
 INSERT INTO system_platform (inventory_id, rh_account, s3_url, vmaas_json, json_checksum) VALUES
 ('INV-ID00-0000-0000', '00000000', 'https://localhost/s3/111111', '{ "package_list": [ "kernel-2.6.32-696.20.1.el6.x86_64" ]}', '11111111'),
 ('INV-ID00-0000-1111', '00000000', 'https://localhost/s3/222222', '{ "package_list": [ "kernel-2.6.32-696.20.1.el6.x86_64" ]}', '11111111'),
-('INV-ID00-0000-2222', '00000000', 'https://localhost/s3/333333', '{ "package_list": [ "kernel-2.6.32-696.20.1.el6.x86_64" ]}', '11111111'),
-('INV-ID00-0000-3333', '00000000', 'https://localhost/s3/444444', '{ "package_list": [ "kernel-2.6.32-696.20.1.el6.x86_64" ]}', '11111111'),
-('INV-ID00-0000-4444', '00000000', 'https://localhost/s3/555555', '{ "package_list": [ "kernel-2.6.32-696.20.1.el6.x86_64" ]}', '11111111'),
-('INV-ID00-0000-5555', '00000000', 'https://localhost/s3/666666', '{ "package_list": [ "kernel-2.6.32-696.20.1.el6.x86_64" ]}', '11111111');
+('INV-ID00-0000-2222', '00000000', 'https://localhost/s3/333333', '{ "package_list": [ "kernel-2.6.32-696.20.1.el6.x86_64" ]}', '11111111');
+
+INSERT INTO system_platform (inventory_id, rh_account, s3_url, vmaas_json, json_checksum, last_evaluation) VALUES
+('INV-ID00-0000-3333', '00000000', 'https://localhost/s3/444444', '{ "package_list": [ "kernel-2.6.32-696.20.1.el6.x86_64" ]}', '11111111', '2018-09-22 12:00:00-04'),
+('INV-ID00-0000-4444', '00000000', 'https://localhost/s3/555555', '{ "package_list": [ "kernel-2.6.32-696.20.1.el6.x86_64" ]}', '11111111', '2018-09-22 12:00:00-04'),
+('INV-ID00-0000-5555', '00000000', 'https://localhost/s3/666666', '{ "package_list": [ "kernel-2.6.32-696.20.1.el6.x86_64" ]}', '11111111', '2018-09-22 12:00:00-04');
 
 INSERT INTO system_platform (inventory_id, rh_account, s3_url, vmaas_json, json_checksum, first_reported, last_updated, unchanged_since) VALUES
 ('INV-ID00-0000-6666', '00000000', 'https://localhost/s3/777777', '{ "package_list": [ "kernel-2.6.32-696.20.1.el6.x86_64" ]}', '11111111', '2017-12-31 08:22:33-04', '2018-10-04 14:13:12-04', '2018-09-22 12:00:00-04');

--- a/database/ve_db_postgresql.sql
+++ b/database/ve_db_postgresql.sql
@@ -90,6 +90,7 @@ CREATE TABLE IF NOT EXISTS system_platform (
   satellite_managed BOOLEAN NOT NULL DEFAULT FALSE,
   last_updated TIMESTAMP WITH TIME ZONE NOT NULL,
   unchanged_since TIMESTAMP WITH TIME ZONE NOT NULL,
+  last_evaluation TIMESTAMP WITH TIME ZONE,
   UNIQUE (inventory_id)
 ) TABLESPACE pg_default;
 
@@ -108,6 +109,8 @@ CREATE TRIGGER system_platform_check_unchanged
   FOR EACH ROW EXECUTE PROCEDURE check_unchanged();
 
 GRANT SELECT, INSERT, UPDATE, DELETE ON system_platform TO ve_db_user_listener;
+-- evaluator needs to update last_evaluation
+GRANT UPDATE ON system_platform TO ve_db_user_evaluator;
 
 
 -- vulnerability_source

--- a/evaluator/evaluator.py
+++ b/evaluator/evaluator.py
@@ -189,6 +189,13 @@ class QueueEvaluator:
         cur.close()
         self.conn.commit()
 
+    def _update_last_evaluation(self, inventory_id):
+        cur = self.conn.cursor()
+        cur.execute("update system_platform set last_evaluation = now() where inventory_id = %s",
+                    (inventory_id,))
+        cur.close()
+        self.conn.commit()
+
     def _change_cve_source(self, inventory_id, source_change_cves, vulnerability_source):
         if not source_change_cves:
             return
@@ -385,6 +392,7 @@ class QueueEvaluator:
             self._store_new_cves(inventory_id, new_cves, self.source_id_map['VMAAS'])
             self._update_mitigated_cves(inventory_id, mitigated_cves, self.source_id_map['VMAAS'])
             self._update_unmitigated_cves(inventory_id, unmitigated_cves, self.source_id_map['VMAAS'])
+            self._update_last_evaluation(inventory_id)
 
         LOGGER.debug("Finished evaluating vulnerabilities for inventory_id: %s", inventory_id)
 

--- a/manager/cve_handler.py
+++ b/manager/cve_handler.py
@@ -16,6 +16,7 @@ class AffectedSystemsView(ListView):
             SystemVulnerabilities
             .select(SystemPlatform.inventory_id,
                     SystemPlatform.satellite_managed,
+                    SystemPlatform.last_evaluation,
                     Status.id.alias('status_id'),
                     Status.name.alias('status_name'))
             .join(SystemPlatform, on=(SystemVulnerabilities.inventory_id == SystemPlatform.inventory_id))
@@ -101,6 +102,7 @@ class CVEHandler(AuthenticatedHandler):
             record['status_id'] = sys['status_id']
             record['status_name'] = sys['status_name']
             record['satellite_managed'] = sys['satellite_managed']
+            record['last_evaluation'] = sys['last_evaluation'].isoformat() if sys['last_evaluation'] else ''
             result.append({'type' : 'system', 'id' : sys['inventory_id'], 'attributes' : record})
         response['meta'] = asys_view.get_metadata()
         response['data'] = self._format_data(list_arguments["data_format"], result)

--- a/manager/system_handler.py
+++ b/manager/system_handler.py
@@ -5,7 +5,7 @@ Module for /systems API endpoint
 import json
 import dateutil.parser
 
-from peewee import Case, fn, JOIN
+from peewee import Case, fn, JOIN, DoesNotExist
 
 from common.peewee_model import CveMetadata, SystemPlatform, SystemVulnerabilities, CveImpact, Status
 from .base import AuthenticatedHandler, parse_url
@@ -122,6 +122,18 @@ class SystemHandler(AuthenticatedHandler):
                      {'arg_name' : 'public_to', 'convert_func' : dateutil.parser.parse}]
         args = self._parse_arguments(args_desc)
         list_arguments = self._parse_list_arguments()
+
+        # check if system was evaluated
+        try:
+            system = (SystemPlatform.select(SystemPlatform.last_evaluation)
+                      .where(SystemPlatform.inventory_id == inventory_id)
+                      .where(SystemPlatform.rh_account == self.rh_account_number)
+                      .get())
+        except DoesNotExist:
+            self.raiseError(404, 'inventory_id must exist and inventory_id must be visible to user', True)
+        if system.last_evaluation is None:
+            self.raiseError(404, 'inventory_id exists but is not evaluated', True)
+
         cves_view = SystemCvesView(list_arguments, {"rh_account_number": self.rh_account_number,
                                                     'inventory_id' : inventory_id}, args)
         response = {}

--- a/manager/system_handler.py
+++ b/manager/system_handler.py
@@ -66,16 +66,19 @@ class SystemView(ListView):
             SystemPlatform
             .select(SystemPlatform.inventory_id,
                     SystemPlatform.satellite_managed,
+                    SystemPlatform.last_evaluation,
                     fn.Count(SystemVulnerabilities.inventory_id).alias('cve_count'))
             .join(SystemVulnerabilities, JOIN.LEFT_OUTER,
                   on=(SystemPlatform.inventory_id == SystemVulnerabilities.inventory_id))
             .where(SystemPlatform.rh_account == query_args['rh_account_number'])
-            .group_by(SystemPlatform.inventory_id, SystemPlatform.satellite_managed)
+            .where(SystemPlatform.last_evaluation.is_null(False))
+            .group_by(SystemPlatform.inventory_id, SystemPlatform.satellite_managed, SystemPlatform.last_evaluation)
             .dicts()
         )
         sortable_columns = {
             'cve_count' : fn.Count(SystemVulnerabilities.inventory_id),
-            'inventory_id' : SystemPlatform.inventory_id
+            'inventory_id' : SystemPlatform.inventory_id,
+            'last_evaluation': SystemPlatform.last_evaluation
         }
         filterable_columns = {
             'inventory_id' : SystemPlatform.inventory_id
@@ -148,6 +151,7 @@ class SystemHandler(AuthenticatedHandler):
         data = []
         for system in system_view:
             record = {}
+            system['last_evaluation'] = system['last_evaluation'].isoformat() if system['last_evaluation'] else ''
             record['attributes'] = system
             record['id'] = system['inventory_id']
             record['type'] = 'system'

--- a/manager/test/test.py
+++ b/manager/test/test.py
@@ -82,7 +82,7 @@ class TestManager:
         assert response.status_code == 200
         payload = response.json()
         meta = assert_meta(payload)
-        assert int(meta['total_items']) == 7
+        assert int(meta['total_items']) == 3
 
     def test_systems_cves(self):
         """/systems/.+/cves endpoint"""

--- a/manager/test/test.py
+++ b/manager/test/test.py
@@ -86,11 +86,15 @@ class TestManager:
 
     def test_systems_cves(self):
         """/systems/.+/cves endpoint"""
+        response = self.call_get('v1.0/systems/INV-INVALID/cves')
+        assert response.status_code == 404
         response = self.call_get('v1.0/systems/INV-ID00-0000-0000/cves')
+        assert response.status_code == 404
+        response = self.call_get('v1.0/systems/INV-ID00-0000-3333/cves')
         assert response.status_code == 200
         payload = response.json()
         meta = assert_meta(payload)
-        assert int(meta['total_items']) == 2
+        assert int(meta['total_items']) == 6
 
     def test_vulnerabilities_cves(self):
         """/vulnerabilities/cves endpoint"""


### PR DESCRIPTION
this PR adds new 'last_evaluation' column for all systems, defaults to NULL, after each evaluation this timestamp is updated

this affects following manager APIs:
- `/r/insights/platform/vulnerability/v1/systems/` - systems with NULL 'last_evaluation' are not included in the list
- `/r/insights/platform/vulnerability/v1/systems/<inventory_id>/cves` - returns 404 if inventory_id either doesn't exist in DB or last_evaluation is NULL for given inventory_id
- `/r/insights/platform/vulnerability/v1/cves/<cve_name>/affected_systems` - adds 'last_evaluation' field for systems in the list

this needs an review if this is correct