### PR TITLE
simplify query by removing redundant condition

### DIFF
--- a/manager/system_handler.py
+++ b/manager/system_handler.py
@@ -33,7 +33,6 @@ class SystemCvesView(ListView):
             .where(SystemVulnerabilities.when_mitigated.is_null(True))
             .where(SystemPlatform.rh_account == query_args['rh_account_number'])
             .where(SystemPlatform.inventory_id == query_args['inventory_id'])
-            .where(SystemPlatform.opt_out == False)  # pylint: disable=singleton-comparison
         )
         if 'cvss_from' in filter_args and filter_args['cvss_from']:
             query = query.where(CveMetadata.cvss3_score >= filter_args['cvss_from'])


### PR DESCRIPTION
opted_out systems are already handled in `get_cves` function, on the line `142` there's an if which throws 404 before this query is called which ensures that `opt_out` is always `False`.