### PR TITLE
reduce number of intermediate Docker images after code change

### DIFF
--- a/Dockerfile-evaluator
+++ b/Dockerfile-evaluator
@@ -7,20 +7,22 @@ RUN yum -y update \
 
 ENV APPBASEDIR=/evaluator
 
-ADD $APPBASEDIR/entrypoint.sh $APPBASEDIR/
-ADD $APPBASEDIR/*.py $APPBASEDIR/evaluator/
-ADD /common/*.py $APPBASEDIR/common/
-ADD wait-for-services.sh $APPBASEDIR/
 ADD scl-enable.sh $APPBASEDIR/
 
-RUN touch $APPBASEDIR/__init__.py
-
 RUN adduser --gid 0 -d $APPBASEDIR --no-create-home -c 'Red Hat Insights' insights
-RUN chown -R insights $APPBASEDIR
 
 RUN $APPBASEDIR/scl-enable.sh pip install --upgrade pip
 
 RUN $APPBASEDIR/scl-enable.sh pip install psycopg2-binary requests prometheus_client "aiokafka==0.5.0"
+
+ADD $APPBASEDIR/entrypoint.sh $APPBASEDIR/
+ADD $APPBASEDIR/*.py $APPBASEDIR/evaluator/
+ADD /common/*.py $APPBASEDIR/common/
+ADD wait-for-services.sh $APPBASEDIR/
+
+RUN touch $APPBASEDIR/__init__.py
+
+RUN chown -R insights $APPBASEDIR
 
 USER insights
 

--- a/Dockerfile-evaluator.rhel7
+++ b/Dockerfile-evaluator.rhel7
@@ -7,20 +7,22 @@ RUN yum -y update \
 
 ENV APPBASEDIR=/evaluator
 
-ADD $APPBASEDIR/entrypoint.sh $APPBASEDIR/
-ADD $APPBASEDIR/*.py $APPBASEDIR/evaluator/
-ADD /common/*.py $APPBASEDIR/common/
-ADD wait-for-services.sh $APPBASEDIR/
 ADD scl-enable.sh $APPBASEDIR/
 
-RUN touch $APPBASEDIR/__init__.py
-
 RUN adduser --gid 0 -d $APPBASEDIR --no-create-home -c 'Red Hat Insights' insights
-RUN chown -R insights $APPBASEDIR
 
 RUN $APPBASEDIR/scl-enable.sh pip install --upgrade pip
 
 RUN $APPBASEDIR/scl-enable.sh pip install psycopg2-binary requests prometheus_client "aiokafka==0.5.0"
+
+ADD $APPBASEDIR/entrypoint.sh $APPBASEDIR/
+ADD $APPBASEDIR/*.py $APPBASEDIR/evaluator/
+ADD /common/*.py $APPBASEDIR/common/
+ADD wait-for-services.sh $APPBASEDIR/
+
+RUN touch $APPBASEDIR/__init__.py
+
+RUN chown -R insights $APPBASEDIR
 
 USER insights
 

--- a/Dockerfile-listener
+++ b/Dockerfile-listener
@@ -7,20 +7,22 @@ RUN yum -y update \
 
 ENV APPBASEDIR=/listener
 
-ADD $APPBASEDIR/*.sh $APPBASEDIR/
-ADD $APPBASEDIR/*.py $APPBASEDIR/listener/
-ADD /common/*.py $APPBASEDIR/common/
 ADD scl-enable.sh $APPBASEDIR/
-ADD wait-for-services.sh $APPBASEDIR/
-
-RUN touch $APPBASEDIR/__init__.py
 
 RUN adduser --gid 0 -d $APPBASEDIR --no-create-home -c 'Red Hat Insights' insights
-RUN chown -R insights $APPBASEDIR
 
 RUN $APPBASEDIR/scl-enable.sh pip install --upgrade pip
 
 RUN $APPBASEDIR/scl-enable.sh pip install psycopg2-binary requests insights-core prometheus_client "aiokafka==0.5.0"
+
+ADD $APPBASEDIR/*.sh $APPBASEDIR/
+ADD $APPBASEDIR/*.py $APPBASEDIR/listener/
+ADD /common/*.py $APPBASEDIR/common/
+ADD wait-for-services.sh $APPBASEDIR/
+
+RUN touch $APPBASEDIR/__init__.py
+
+RUN chown -R insights $APPBASEDIR
 
 USER insights
 

--- a/Dockerfile-listener.rhel7
+++ b/Dockerfile-listener.rhel7
@@ -7,20 +7,22 @@ RUN yum -y update \
 
 ENV APPBASEDIR=/listener
 
-ADD $APPBASEDIR/*.sh $APPBASEDIR/
-ADD $APPBASEDIR/*.py $APPBASEDIR/listener/
-ADD /common/*.py $APPBASEDIR/common/
 ADD scl-enable.sh $APPBASEDIR/
-ADD wait-for-services.sh $APPBASEDIR/
-
-RUN touch $APPBASEDIR/__init__.py
 
 RUN adduser --gid 0 -d $APPBASEDIR --no-create-home -c 'Red Hat Insights' insights
-RUN chown -R insights $APPBASEDIR
 
 RUN $APPBASEDIR/scl-enable.sh pip install --upgrade pip
 
 RUN $APPBASEDIR/scl-enable.sh pip install psycopg2-binary requests insights-core prometheus_client "aiokafka==0.5.0"
+
+ADD $APPBASEDIR/*.sh $APPBASEDIR/
+ADD $APPBASEDIR/*.py $APPBASEDIR/listener/
+ADD /common/*.py $APPBASEDIR/common/
+ADD wait-for-services.sh $APPBASEDIR/
+
+RUN touch $APPBASEDIR/__init__.py
+
+RUN chown -R insights $APPBASEDIR
 
 USER insights
 

--- a/Dockerfile-platform-mock
+++ b/Dockerfile-platform-mock
@@ -7,13 +7,11 @@ RUN yum -y update \
 
 ENV APPBASEDIR=/platform_mock
 
-ADD $APPBASEDIR/*.sh $APPBASEDIR/
-ADD $APPBASEDIR/*.py $APPBASEDIR$APPBASEDIR/
-ADD /common/*.py $APPBASEDIR/common/
 ADD scl-enable.sh $APPBASEDIR/
-ADD wait-for-services.sh $APPBASEDIR/
 
-RUN touch $APPBASEDIR/__init__.py
+RUN $APPBASEDIR/scl-enable.sh pip install --upgrade pip
+
+RUN $APPBASEDIR/scl-enable.sh pip install tornado "aiokafka==0.5.0" insights-core
 
 RUN cd $APPBASEDIR \
         && mkdir kafka \
@@ -22,11 +20,13 @@ RUN cd $APPBASEDIR \
 
 RUN adduser --gid 0 -d $APPBASEDIR --no-create-home -c 'Red Hat Insights' insights
 
+ADD $APPBASEDIR/*.sh $APPBASEDIR/
+ADD $APPBASEDIR/*.py $APPBASEDIR$APPBASEDIR/
+ADD /common/*.py $APPBASEDIR/common/
+ADD wait-for-services.sh $APPBASEDIR/
+RUN touch $APPBASEDIR/__init__.py
+
 RUN chown -R insights $APPBASEDIR
-
-RUN $APPBASEDIR/scl-enable.sh pip install --upgrade pip
-
-RUN $APPBASEDIR/scl-enable.sh pip install tornado "aiokafka==0.5.0" insights-core
 
 USER insights
 

--- a/Dockerfile-vmaas-sync
+++ b/Dockerfile-vmaas-sync
@@ -7,20 +7,22 @@ RUN yum -y update \
 
 ENV APPBASEDIR=/vmaas_sync
 
-ADD $APPBASEDIR/*.sh $APPBASEDIR/
-ADD $APPBASEDIR/*.py $APPBASEDIR/vmaas_sync/
-ADD /common/*.py $APPBASEDIR/common/
 ADD scl-enable.sh $APPBASEDIR/
-ADD wait-for-services.sh $APPBASEDIR/
-
-RUN touch $APPBASEDIR/__init__.py
 
 RUN adduser --gid 0 -d $APPBASEDIR --no-create-home -c 'Red Hat Insights' insights
-RUN chown -R insights $APPBASEDIR
 
 RUN $APPBASEDIR/scl-enable.sh pip install --upgrade pip
 
 RUN $APPBASEDIR/scl-enable.sh pip install tornado prometheus_client "aiokafka==0.5.0"
+
+ADD $APPBASEDIR/*.sh $APPBASEDIR/
+ADD $APPBASEDIR/*.py $APPBASEDIR/vmaas_sync/
+ADD /common/*.py $APPBASEDIR/common/
+ADD wait-for-services.sh $APPBASEDIR/
+
+RUN touch $APPBASEDIR/__init__.py
+
+RUN chown -R insights $APPBASEDIR
 
 USER insights
 

--- a/Dockerfile-vmaas-sync.rhel7
+++ b/Dockerfile-vmaas-sync.rhel7
@@ -7,20 +7,22 @@ RUN yum -y update \
 
 ENV APPBASEDIR=/vmaas_sync
 
-ADD $APPBASEDIR/*.sh $APPBASEDIR/
-ADD $APPBASEDIR/*.py $APPBASEDIR/vmaas_sync/
-ADD /common/*.py $APPBASEDIR/common/
 ADD scl-enable.sh $APPBASEDIR/
-ADD wait-for-services.sh $APPBASEDIR/
-
-RUN touch $APPBASEDIR/__init__.py
 
 RUN adduser --gid 0 -d $APPBASEDIR --no-create-home -c 'Red Hat Insights' insights
-RUN chown -R insights $APPBASEDIR
 
 RUN $APPBASEDIR/scl-enable.sh pip install --upgrade pip
 
 RUN $APPBASEDIR/scl-enable.sh pip install tornado prometheus_client "aiokafka==0.5.0"
+
+ADD $APPBASEDIR/*.sh $APPBASEDIR/
+ADD $APPBASEDIR/*.py $APPBASEDIR/vmaas_sync/
+ADD /common/*.py $APPBASEDIR/common/
+ADD wait-for-services.sh $APPBASEDIR/
+
+RUN touch $APPBASEDIR/__init__.py
+
+RUN chown -R insights $APPBASEDIR
 
 USER insights
 


### PR DESCRIPTION
Previously we were adding our code before running e.g. pip install or other things which are changing less often and have bigger layers than our code.
I've restructured the Dockerfiles in a way that things that are changing the least and take the biggest amount of time are run first, and our code is added at last possible place so we won't run whole `pip install --upgrade && pip install $LOT_OF_STUFF` after one line of code gets changed.