### PR TITLE
Make sure admin user has createrole attribute

### DIFF
--- a/database/schema/init_schema.sh
+++ b/database/schema/init_schema.sh
@@ -8,6 +8,9 @@ if $PG_INITIALIZED ; then
     psql -c "ALTER USER ve_db_user_evaluator WITH PASSWORD '${VE_DB_USER_EVALUATOR_PASSWORD}'" -d ${POSTGRESQL_DATABASE}
     psql -c "ALTER USER ve_db_user_listener WITH PASSWORD '${VE_DB_USER_LISTENER_PASSWORD}'" -d ${POSTGRESQL_DATABASE}
     psql -c "ALTER USER ve_db_user_vmaas_sync WITH PASSWORD '${VE_DB_USER_VMAAS_SYNC_PASSWORD}'" -d ${POSTGRESQL_DATABASE}
+    # Need to make sure admin role has createrole attribute
+    psql -c "ALTER USER ${POSTGRESQL_USER} WITH CREATEROLE" -d ${POSTGRESQL_DATABASE}
 else
     echo "Schema initialization skipped."
 fi
+


### PR DESCRIPTION
To support database upgrade, the admin user (ve_db_admin) must have CREATEROLE attribute so it is able to create new roles in upgrade scripts.  The 003-...sql upgrade script needs this support.

This PR will cause the admin user to have the CREATEROLE attribute.  If the vulnerability-engine-database image is updated and deployed where the database already exists, it will still ensure the admin user is modified with the CREATEROLE attribute.

In the alternative, one can attach to the database container an issue the alter user command manually...

In the UI, go to the terminal for the running database pod and issue this command:
**psql -c "ALTER USER ve_db_admin WITH CREATEROLE" -d vulnerability**

Or from the command line, exec to the container and run bash, then issue the above command:
**docker exec -it ve_db_ctr bash**
bash-4.2$ **psql -c "ALTER USER ve_db_admin WITH CREATEROLE" -d vulnerability**

I have already done this in the vulnerability-engine-ci environment.