### PR TITLE
Add unit-tests for status-handler

### DIFF
--- a/manager/status_handler.py
+++ b/manager/status_handler.py
@@ -4,7 +4,7 @@ Module for /status API endpoint
 
 import json
 
-from peewee import DoesNotExist, IntegrityError
+from peewee import IntegrityError
 
 from common.logging import get_logger
 from common.peewee_model import DB, SystemPlatform, SystemVulnerabilities, Status
@@ -129,10 +129,7 @@ class StatusHandler(AuthenticatedHandler):
                 # sysid/cve/acct combination does not exist
                 self.raiseError(404, 'inventory_id/cve must exist and inventory_id must be visible to user')
             self.flush()
-        except DoesNotExist:
-            # sysid/cve/acct combination does not exist
-            self.raiseError(404, 'inventory_id/cve must exist and inventory_id must be visible to user')
-        except IntegrityError as integ_error:
+        except (IntegrityError, ValueError) as integ_error:
             # usually means bad-status-id
             DB.rollback()
             self.raiseError(400, str(integ_error))

--- a/tests/manager_tests/test_manager.py
+++ b/tests/manager_tests/test_manager.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# pylint: disable=missing-docstring,too-many-public-methods,invalid-name
+# pylint: disable=missing-docstring,too-many-public-methods,invalid-name,protected-access,eval-used
 """
 Vulnerability manager tests.
 """
@@ -187,3 +187,36 @@ class TestSystemHandler(ManagerHTTPTestCase):
         self.vfetch("systems/INV-ID00-0000-4444/opt_out?value=false", body="", method="PATCH")
         hidden = self.vfetch("systems?opt_out=true")
         assert not hidden.body.data
+
+    def test_status_list(self):
+        status = self.vfetch('status')
+        assert status.raw._body
+        body_array = eval(status.raw._body)
+        assert len(body_array) == 7
+        assert body_array[0]['id'] == 0
+        assert body_array[0]['name'] == 'Not Reviewed'
+
+    def test_status_invalid(self):
+        self.vfetch('status', body='', method='POST').check_response(400)
+        self.vfetch('status', body='', method='PATCH').check_response(400)
+        self.vfetch('status', body='{"cve":"CVE-2014-0160", "status_id":"2"}',
+                    method='PATCH').check_response(400)
+        self.vfetch('status', body='{"inventory_id": "INV-ID00-0000-0000", "status_id":"2"}',
+                    method='PATCH').check_response(400)
+        self.vfetch('status', body='{"inventory_id": "INV-ID00-0000-0000", "cve":"CVE-2014-0160", }',
+                    method='PATCH').check_response(400)
+        self.vfetch('status', body='{"inventory_id": "INV-ID00-0000-0000", "cve":"CVE-2014-0160", "status_id":"2"',
+                    method='PATCH').check_response(400)
+        self.vfetch('status', body='{"inventory_id": "INV-ID00-0000-0000", "cve":"CVE-2014-abcdef, "status_id":"2"}',
+                    method='PATCH').check_response(400)
+        self.vfetch('status', body='{"inventory_id": "INV-ID00-0000-0000", "cve":"CVE-2014-0160", "status_id":"a"}',
+                    method='PATCH').check_response(400)
+        self.vfetch('status', body='{"inventory_id": "INV-ID00-0000-1234", "cve":"CVE-2014-0160", "status_id":"2"}',
+                    method='PATCH').check_response(404)
+
+    def test_status(self):
+        self.vfetch('status', body='{"inventory_id": "INV-ID00-0000-0000", "cve":"CVE-2014-0160", "status_id":"2"}',
+                    method='PATCH').check_response()
+        self.vfetch('status', body='{"inventory_id": "INV-ID00-0000-0000", "cve":"CVE-2014-0160", "status_id":"2"}',
+                    method='POST').check_response()
+        assert True


### PR DESCRIPTION
Now that pytests use postgresql, submitting unit-test coverage for status