### PR TITLE
Add upgrade test

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,2 @@
 [run]
-source = common, evaluator, listener, manager, vmaas_sync
+source = common, database, evaluator, listener, manager, vmaas_sync

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+git:
+  depth: false
 branches:
   only:
     - master

--- a/database/schema/upgrade_scripts/001-db-upgrade-support.sql
+++ b/database/schema/upgrade_scripts/001-db-upgrade-support.sql
@@ -28,3 +28,19 @@ CREATE INDEX ON db_upgrade_log(version);
 CREATE TRIGGER db_upgrade_log_set_last_updated
   BEFORE INSERT OR UPDATE ON db_upgrade_log
   FOR EACH ROW EXECUTE PROCEDURE set_last_updated();
+
+
+-- user for evaluator component
+GRANT SELECT ON db_version TO ve_db_user_evaluator;
+GRANT SELECT ON db_upgrade_log TO ve_db_user_evaluator;
+GRANT USAGE, SELECT ON db_upgrade_log_id_seq TO ve_db_user_evaluator;
+
+-- user for listener component
+GRANT SELECT ON db_version TO ve_db_user_listener;
+GRANT SELECT ON db_upgrade_log TO ve_db_user_listener;
+GRANT USAGE, SELECT ON db_upgrade_log_id_seq TO ve_db_user_listener;
+
+-- user for UI manager component
+GRANT SELECT ON db_version TO ve_db_user_manager;
+GRANT SELECT ON db_upgrade_log TO ve_db_user_manager;
+

--- a/database/upgrade/upgrade.py
+++ b/database/upgrade/upgrade.py
@@ -4,8 +4,9 @@ database upgrade
 """
 
 import os
-import psycopg2
 import subprocess
+
+import psycopg2
 
 from common.database_handler import DatabaseHandler, init_db
 from common.logging import init_logging, get_logger
@@ -20,7 +21,7 @@ class DatabaseUpgrade:
     # directory where the upgrade sql scripts are located.
     # must end with '/' character.
     scripts_dir = None
-    
+
     # map of version to which a script upgrades the db to
     # the name of the script.
     version2file_map = None
@@ -29,7 +30,7 @@ class DatabaseUpgrade:
     # version to which the db will be upgraded.
     version_max = 0
 
-    
+
     def __init__(self):
         LOGGER.info('DatabaseUpgrade initializing.')
 
@@ -47,28 +48,30 @@ class DatabaseUpgrade:
         self.conn = DatabaseHandler.get_connection()
 
     def upgrade(self):
+        """perform database upgrade"""
         try:
             self._get_db_lock()
 
             db_version = self._get_current_db_version()
 
             if db_version == self.version_max:
-                LOGGER.info('Database is up to date at version: %d' % db_version)
+                LOGGER.info('Database is up to date at version: %d', db_version)
                 return
             if db_version > self.version_max:
                 msg = 'Database version %d is greater than upgrade version %d' % (db_version, self.version_max)
                 LOGGER.warning(msg)
                 return
 
-            LOGGER.info('Database requires upgrade from version %d to %d' % (db_version, self.version_max))
+            LOGGER.info('Database requires upgrade from version %d to %d', db_version, self.version_max)
             upgrades_to_apply = self._get_upgrades_to_apply(db_version, self.version_max)
             for upgrade in upgrades_to_apply:
                 self._apply_upgrade(upgrade['ver'], upgrade['script'])
         finally:
             self._release_db_lock()
 
-    def _load_upgrade_file_list(self, scripts_dir):
-        LOGGER.info('Building upgrade script list from directory %s' % scripts_dir)
+    @staticmethod
+    def _load_upgrade_file_list(scripts_dir):
+        LOGGER.info('Building upgrade script list from directory %s', scripts_dir)
         max_version = 0
         ver2file_map = {}
         files = os.listdir(scripts_dir)
@@ -76,7 +79,7 @@ class DatabaseUpgrade:
             if name.endswith('.sql'):
                 result = name.split('-', 1)
                 if len(result) != 2:
-                    LOGGER.info('ignoring file using different name format: %s' % name)
+                    LOGGER.info('ignoring file using different name format: %s', name)
                 else:
                     try:
                         file_num = int(result[0])
@@ -84,15 +87,15 @@ class DatabaseUpgrade:
                             raise Exception('Found two files with same file number',
                                             ver2file_map[file_num],
                                             name)
-                        LOGGER.debug('adding to list file version %d: %s' % (file_num, name))
-                        ver2file_map[file_num] = { 'ver': file_num, 'script': name }
+                        LOGGER.debug('adding to list file version %d: %s', file_num, name)
+                        ver2file_map[file_num] = {'ver': file_num, 'script': name}
                         if file_num > max_version:
-                            LOGGER.debug('max version raised to %d' % file_num)
+                            LOGGER.debug('max version raised to %d', file_num)
                             max_version = file_num
                     except ValueError:
-                        LOGGER.info('ignoring file with non-numeric prefix: %s' % name)
+                        LOGGER.info('ignoring file with non-numeric prefix: %s', name)
             else:
-                LOGGER.info('ignoring file without .sql suffix: %s' % name)
+                LOGGER.info('ignoring file without .sql suffix: %s', name)
         return ver2file_map, max_version
 
     def _get_upgrades_to_apply(self, current_ver, upgrade_ver):
@@ -108,11 +111,11 @@ class DatabaseUpgrade:
         return upgrades_to_apply
 
     def _apply_upgrade(self, version, script_file):
-        LOGGER.info('applying upgrade to version %d' % version)
+        LOGGER.info('applying upgrade to version %d', version)
         if version > 1:
             self._insert_log_entry(version, 'starting', script_file)
 
-        psql_env = { 'PGPASSWORD': DatabaseHandler.db_pass }
+        psql_env = {'PGPASSWORD': DatabaseHandler.db_pass}
         psql = subprocess.run(['/usr/bin/psql', '--no-password',
                                '-h', DatabaseHandler.db_host,
                                '-p', str(DatabaseHandler.db_port),
@@ -167,7 +170,7 @@ class DatabaseUpgrade:
             if not result:
                 raise Exception("db_version table exists, but no row with name '%s'" % SCHEMA_VER_NAME)
             db_version = result[0]
-        except psycopg2.ProgrammingError as ex:
+        except psycopg2.ProgrammingError:
             db_version = 0
         finally:
             cur.close()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 aiokafka==0.5.0
 connexion
+gitpython
 insights-core
 peewee
 pre-commit

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -24,7 +24,7 @@ done
 echo ""
 
 # Run pylint
-for testdir in common listener evaluator manager tests vmaas_sync
+for testdir in common database listener evaluator manager tests vmaas_sync
 do
     echo "Running pylint on module: $testdir"
     pylint --rcfile=./pylintrc $testdir

--- a/tests/database_tests/test_upgrade.py
+++ b/tests/database_tests/test_upgrade.py
@@ -14,7 +14,7 @@ from database.upgrade import upgrade
 from ..utils import get_pg_class, set_env, VULN_ENG_DIR
 
 
-UPGRADE_FROM = os.getenv("UPGRADE_FROM", "a3388e0b8643e7b022947fb2c0c2f862ef0056b0")
+UPGRADE_FROM = os.getenv("UPGRADE_FROM", "4448350601fc0b9f0fb65b4e49e0af8f66018587")
 UPGRADE_TO = os.getenv("UPGRADE_TO", None)
 STATIC_TABLES = ["db_version", "cve_impact", "status"]
 
@@ -55,8 +55,11 @@ class TestUpgrade:
     def pg_old(self, commit=UPGRADE_FROM):
         """Setup DB that will be upgraded."""
         stashed = self._git_checkout(commit)
-        # start DB with old schema
-        postgres_class = get_pg_class()
+        # start DB with old schema, also path to init scripts was different
+        ve_user = VULN_ENG_DIR.joinpath("database", "ve_db_user_create_postgresql.sql")
+        ve_pg = VULN_ENG_DIR.joinpath("database", "ve_db_postgresql.sql")
+        ve_data = VULN_ENG_DIR.joinpath("database", "ve_db_dev_data.sql")
+        postgres_class = get_pg_class(ve_user=ve_user, ve_pg=ve_pg, ve_data=ve_data)
         postgres = postgres_class()
         set_env(postgres)
         yield postgres

--- a/tests/database_tests/test_upgrade.py
+++ b/tests/database_tests/test_upgrade.py
@@ -8,7 +8,7 @@ import re
 import subprocess
 
 import pytest
-from git import GitCommandError, Repo
+from git import Repo
 
 from database.upgrade import upgrade
 from ..utils import get_pg_class, set_env, VULN_ENG_DIR
@@ -31,28 +31,30 @@ class TestUpgrade:
 
     def _git_checkout(self, commit):
         """Perform git checkout specified by commit and stash current work"""
-        self.repo.git.stash()
+        stashed = False
+        if self.repo.is_dirty():
+            self.repo.git.stash()
+            stashed = True
         # checkout branch `commit` or branch from what tests where executed
         self.repo.head.reference = self.head
         if commit:
             self.repo.head.reference = self.repo.create_head(commit[:7], commit=commit)
         self.repo.head.reset(index=True, working_tree=True)
+        return stashed
 
-    def _git_co_teardown(self, commit):
+    def _git_co_teardown(self, commit, stashed):
         """Checkout to previous branch and apply last stash"""
         self.repo.head.reference = self.head
         self.repo.head.reset(index=True, working_tree=True)
         if commit:
             self.repo.delete_head(commit[:7])
-        try:
-            self.repo.git.stash("apply")
-        except GitCommandError:
-            pass
+        if stashed:
+            self.repo.git.stash("pop")
 
     @pytest.fixture
     def pg_old(self, commit=UPGRADE_FROM):
         """Setup DB that will be upgraded."""
-        self._git_checkout(commit)
+        stashed = self._git_checkout(commit)
         # start DB with old schema
         postgres_class = get_pg_class()
         postgres = postgres_class()
@@ -61,12 +63,12 @@ class TestUpgrade:
 
         postgres.stop()
         postgres_class.clear_cache()
-        self._git_co_teardown(commit)
+        self._git_co_teardown(commit, stashed)
 
     @pytest.fixture
     def pg_new(self, commit=UPGRADE_TO):
         """Setup DB that uses already upgraded schema."""
-        self._git_checkout(commit)
+        stashed = self._git_checkout(commit)
         # start DB with new schema
         postgres_class = get_pg_class()
         postgres = postgres_class()
@@ -75,7 +77,7 @@ class TestUpgrade:
 
         postgres.stop()
         postgres_class.clear_cache()
-        self._git_co_teardown(commit)
+        self._git_co_teardown(commit, stashed)
 
     def _create_dump(self, args):
         dump = subprocess.check_output(args).decode("utf-8")

--- a/tests/database_tests/test_upgrade.py
+++ b/tests/database_tests/test_upgrade.py
@@ -22,7 +22,11 @@ class TestUpgrade:
     """Tests for vulnerability-engine database upgrade."""
 
     repo = Repo(VULN_ENG_DIR)
-    head = repo.head.reference
+    if repo.head.is_detached:
+        # HEAD is detached in Travis, create branch from head.commit
+        head = repo.create_head(repo.head.commit.name_rev[:7], commit=repo.head.commit.hexsha)
+    else:
+        head = repo.head.reference
 
     def _git_checkout(self, commit):
         """Perform git checkout specified by commit and stash current work"""

--- a/tests/database_tests/test_upgrade.py
+++ b/tests/database_tests/test_upgrade.py
@@ -1,0 +1,112 @@
+# pylint: disable=no-self-use
+"""
+Test database upgrades
+"""
+import difflib
+import os
+import re
+import subprocess
+
+import pytest
+from git import GitCommandError, Repo
+
+from database.upgrade import upgrade
+from ..utils import get_pg_class, set_env, VULN_ENG_DIR
+
+
+UPGRADE_FROM = os.getenv("UPGRADE_FROM", "a3388e0b8643e7b022947fb2c0c2f862ef0056b0")
+UPGRADE_TO = os.getenv("UPGRADE_TO", None)
+
+
+class TestUpgrade:
+    """Tests for vulnerability-engine database upgrade."""
+
+    repo = Repo(VULN_ENG_DIR)
+    head = repo.head.reference
+
+    def _git_checkout(self, commit):
+        """Perform git checkout specified by commit and stash current work"""
+        self.repo.git.stash()
+        # checkout branch `commit` or branch from what tests where executed
+        self.repo.head.reference = self.head
+        if commit:
+            self.repo.head.reference = self.repo.create_head(commit[:7], commit=commit)
+        self.repo.head.reset(index=True, working_tree=True)
+
+    def _git_co_teardown(self):
+        """Checkout to previous branch and apply last stash"""
+        self.repo.head.reference = self.head
+        self.repo.head.reset(index=True, working_tree=True)
+        try:
+            self.repo.git.stash("apply")
+        except GitCommandError:
+            pass
+
+    @pytest.fixture
+    def pg_old(self, commit=UPGRADE_FROM):
+        """Setup DB that will be upgraded."""
+        self._git_checkout(commit)
+        # start DB with old schema
+        postgres_class = get_pg_class()
+        postgres = postgres_class()
+        set_env(postgres)
+        yield postgres
+
+        postgres.stop()
+        postgres_class.clear_cache()
+        self._git_co_teardown()
+
+    @pytest.fixture
+    def pg_new(self, commit=UPGRADE_TO):
+        """Setup DB that uses already upgraded schema."""
+        self._git_checkout(commit)
+        # start DB with new schema
+        postgres_class = get_pg_class()
+        postgres = postgres_class()
+        set_env(postgres)
+        yield postgres
+
+        postgres.stop()
+        postgres_class.clear_cache()
+        self._git_co_teardown()
+
+    def test_upgrade(self, pg_old, pg_new):
+        """Test schema upgrade."""
+        env_old = pg_old.dsn()
+        env_new = pg_new.dsn()
+
+        os.environ["POSTGRESQL_USER"] = "ve_db_admin"
+        os.environ["POSTGRESQL_PASSWORD"] = "ve_db_admin_pwd"
+        os.environ["POSTGRESQL_PORT"] = str(env_old["port"])
+
+        upgrade.main()
+
+        dump_old = subprocess.check_output(
+            [
+                "pg_dump", "-s",
+                "-h", str(env_old["host"]),
+                "-p", str(env_old["port"]),
+                "-U", env_old["user"],
+                "-d", env_old["database"],
+            ]
+        ).decode("utf-8")
+        dump_new = subprocess.check_output(
+            [
+                "pg_dump", "-s",
+                "-h", str(env_new["host"]),
+                "-p", str(env_new["port"]),
+                "-U", env_new["user"],
+                "-d", env_new["database"],
+            ]
+        ).decode("utf-8")
+
+        dump_old = re.sub(r"\n+", "\n", dump_old).splitlines()
+        dump_new = re.sub(r"\n+", "\n", dump_new).splitlines()
+        dump_old.sort()
+        dump_new.sort()
+        try:
+            assert dump_old == dump_new
+        except AssertionError:
+            diff = difflib.unified_diff(dump_old, dump_new)
+            diffs = "\n".join([x for x in diff])
+            assert False, f"Diff:\n{diffs}"

--- a/tests/database_tests/test_upgrade.py
+++ b/tests/database_tests/test_upgrade.py
@@ -16,6 +16,7 @@ from ..utils import get_pg_class, set_env, VULN_ENG_DIR
 
 UPGRADE_FROM = os.getenv("UPGRADE_FROM", "a3388e0b8643e7b022947fb2c0c2f862ef0056b0")
 UPGRADE_TO = os.getenv("UPGRADE_TO", None)
+STATIC_TABLES = ["db_version", "cve_impact", "status"]
 
 
 class TestUpgrade:
@@ -74,6 +75,12 @@ class TestUpgrade:
         postgres_class.clear_cache()
         self._git_co_teardown()
 
+    def _create_dump(self, args):
+        dump = subprocess.check_output(args).decode("utf-8")
+        dump = re.sub(r"\n+", "\n", dump).splitlines()
+        dump.sort()
+        return dump
+
     def test_upgrade(self, pg_old, pg_new):
         """Test schema upgrade."""
         env_old = pg_old.dsn()
@@ -85,29 +92,49 @@ class TestUpgrade:
 
         upgrade.main()
 
-        dump_old = subprocess.check_output(
-            [
-                "pg_dump", "-s",
-                "-h", str(env_old["host"]),
-                "-p", str(env_old["port"]),
-                "-U", env_old["user"],
-                "-d", env_old["database"],
-            ]
-        ).decode("utf-8")
-        dump_new = subprocess.check_output(
-            [
-                "pg_dump", "-s",
-                "-h", str(env_new["host"]),
-                "-p", str(env_new["port"]),
-                "-U", env_new["user"],
-                "-d", env_new["database"],
-            ]
-        ).decode("utf-8")
+        schema_old_args = [
+            "pg_dump", "-s",
+            "-h", str(env_old["host"]),
+            "-p", str(env_old["port"]),
+            "-U", env_old["user"],
+            "-d", env_old["database"],
+        ]
+        schema_new_args = [
+            "pg_dump", "-s",
+            "-h", str(env_new["host"]),
+            "-p", str(env_new["port"]),
+            "-U", env_new["user"],
+            "-d", env_new["database"],
+        ]
 
-        dump_old = re.sub(r"\n+", "\n", dump_old).splitlines()
-        dump_new = re.sub(r"\n+", "\n", dump_new).splitlines()
-        dump_old.sort()
-        dump_new.sort()
+        dump_old = self._create_dump(schema_old_args)
+        dump_new = self._create_dump(schema_new_args)
+        try:
+            assert dump_old == dump_new
+        except AssertionError:
+            diff = difflib.unified_diff(dump_old, dump_new)
+            diffs = "\n".join([x for x in diff])
+            assert False, f"Diff:\n{diffs}"
+
+        data_args = ["pg_dump", "-a"]
+        for table_name in STATIC_TABLES:
+            data_args.append("-t")
+            data_args.append(table_name)
+        data_old_args = data_args + [
+            "-h", str(env_old["host"]),
+            "-p", str(env_old["port"]),
+            "-U", env_old["user"],
+            "-d", env_old["database"],
+        ]
+        data_new_args = data_args + [
+            "-h", str(env_new["host"]),
+            "-p", str(env_new["port"]),
+            "-U", env_new["user"],
+            "-d", env_new["database"],
+        ]
+
+        dump_old = self._create_dump(data_old_args)
+        dump_new = self._create_dump(data_new_args)
         try:
             assert dump_old == dump_new
         except AssertionError:

--- a/tests/database_tests/test_upgrade.py
+++ b/tests/database_tests/test_upgrade.py
@@ -38,10 +38,12 @@ class TestUpgrade:
             self.repo.head.reference = self.repo.create_head(commit[:7], commit=commit)
         self.repo.head.reset(index=True, working_tree=True)
 
-    def _git_co_teardown(self):
+    def _git_co_teardown(self, commit):
         """Checkout to previous branch and apply last stash"""
         self.repo.head.reference = self.head
         self.repo.head.reset(index=True, working_tree=True)
+        if commit:
+            self.repo.delete_head(commit[:7])
         try:
             self.repo.git.stash("apply")
         except GitCommandError:
@@ -59,7 +61,7 @@ class TestUpgrade:
 
         postgres.stop()
         postgres_class.clear_cache()
-        self._git_co_teardown()
+        self._git_co_teardown(commit)
 
     @pytest.fixture
     def pg_new(self, commit=UPGRADE_TO):
@@ -73,7 +75,7 @@ class TestUpgrade:
 
         postgres.stop()
         postgres_class.clear_cache()
-        self._git_co_teardown()
+        self._git_co_teardown(commit)
 
     def _create_dump(self, args):
         dump = subprocess.check_output(args).decode("utf-8")

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -38,9 +38,9 @@ def check_open_port(host, port):
 
 
 @contextmanager
-def connect_pg(postgresql):
+def connect_pg(postgresql, **kwargs):
     """PostgreSQL cursor context manager."""
-    conn = psycopg2.connect(**postgresql.dsn())
+    conn = psycopg2.connect(**postgresql.dsn(**kwargs))
     cursor = conn.cursor()
     yield cursor
     cursor.close()
@@ -54,6 +54,11 @@ def get_pg_class():
     def _handler(postgresql):
         """Initializes PostgreSQL with data."""
         with connect_pg(postgresql) as cursor:
+            pg_env = postgresql.dsn()
+            cursor.execute("CREATE USER ve_db_admin WITH CREATEROLE")
+            cursor.execute("ALTER USER ve_db_admin WITH PASSWORD 've_db_admin_pwd'")
+            cursor.execute(f"ALTER DATABASE {pg_env['database']} OWNER TO ve_db_admin")
+        with connect_pg(postgresql, user="ve_db_admin") as cursor:
             cursor.execute(VE_USER.read_text())
             cursor.execute(VE_PG.read_text())
             cursor.execute(VE_DATA.read_text())

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -48,7 +48,7 @@ def connect_pg(postgresql, **kwargs):
     conn.close()
 
 
-def get_pg_class():
+def get_pg_class(ve_user=VE_USER, ve_pg=VE_PG, ve_data=VE_DATA):
     """Setup PostgreSQL class."""
 
     def _handler(postgresql):
@@ -59,9 +59,9 @@ def get_pg_class():
             cursor.execute("ALTER USER ve_db_admin WITH PASSWORD 've_db_admin_pwd'")
             cursor.execute(f"ALTER DATABASE {pg_env['database']} OWNER TO ve_db_admin")
         with connect_pg(postgresql, user="ve_db_admin") as cursor:
-            cursor.execute(VE_USER.read_text())
-            cursor.execute(VE_PG.read_text())
-            cursor.execute(VE_DATA.read_text())
+            cursor.execute(ve_user.read_text())
+            cursor.execute(ve_pg.read_text())
+            cursor.execute(ve_data.read_text())
 
     # create temporary posgresql server
     # pylint: disable=invalid-name


### PR DESCRIPTION
1. setup 2 databases (old schema, new schema) with dev_data
2. upgrade the old one and compare schema only dumps

By default it will upgrade DB from a3388e0b8643e7b022947fb2c0c2f862ef0056b0 to schema from current branch. If you want to test upgrade with between different schemas, you can specify commits in `UPGRADE_FROM` and `UPGRADE_TO` env variables