### PR TITLE
use fixed versions of python libraries in requirements-xxx.txt files

### DIFF
--- a/Dockerfile-evaluator
+++ b/Dockerfile-evaluator
@@ -8,12 +8,13 @@ RUN yum -y update \
 ENV APPBASEDIR=/evaluator
 
 ADD scl-enable.sh $APPBASEDIR/
+ADD requirements-evaluator.txt $APPBASEDIR/
 
 RUN adduser --gid 0 -d $APPBASEDIR --no-create-home -c 'Red Hat Insights' insights
 
 RUN $APPBASEDIR/scl-enable.sh pip install --upgrade pip
 
-RUN $APPBASEDIR/scl-enable.sh pip install psycopg2-binary requests prometheus_client "aiokafka==0.5.0"
+RUN $APPBASEDIR/scl-enable.sh pip install -r $APPBASEDIR/requirements-evaluator.txt
 
 ADD $APPBASEDIR/entrypoint.sh $APPBASEDIR/
 ADD $APPBASEDIR/*.py $APPBASEDIR/evaluator/

--- a/Dockerfile-evaluator.rhel7
+++ b/Dockerfile-evaluator.rhel7
@@ -8,12 +8,13 @@ RUN yum -y update \
 ENV APPBASEDIR=/evaluator
 
 ADD scl-enable.sh $APPBASEDIR/
+ADD requirements-evaluator.txt $APPBASEDIR/
 
 RUN adduser --gid 0 -d $APPBASEDIR --no-create-home -c 'Red Hat Insights' insights
 
 RUN $APPBASEDIR/scl-enable.sh pip install --upgrade pip
 
-RUN $APPBASEDIR/scl-enable.sh pip install psycopg2-binary requests prometheus_client "aiokafka==0.5.0"
+RUN $APPBASEDIR/scl-enable.sh pip install -r $APPBASEDIR/requirements-evaluator.txt
 
 ADD $APPBASEDIR/entrypoint.sh $APPBASEDIR/
 ADD $APPBASEDIR/*.py $APPBASEDIR/evaluator/

--- a/Dockerfile-listener
+++ b/Dockerfile-listener
@@ -8,12 +8,13 @@ RUN yum -y update \
 ENV APPBASEDIR=/listener
 
 ADD scl-enable.sh $APPBASEDIR/
+ADD requirements-listener.txt $APPBASEDIR/
 
 RUN adduser --gid 0 -d $APPBASEDIR --no-create-home -c 'Red Hat Insights' insights
 
 RUN $APPBASEDIR/scl-enable.sh pip install --upgrade pip
 
-RUN $APPBASEDIR/scl-enable.sh pip install psycopg2-binary requests insights-core prometheus_client "aiokafka==0.5.0"
+RUN $APPBASEDIR/scl-enable.sh pip install -r $APPBASEDIR/requirements-listener.txt
 
 ADD $APPBASEDIR/*.sh $APPBASEDIR/
 ADD $APPBASEDIR/*.py $APPBASEDIR/listener/

--- a/Dockerfile-listener.rhel7
+++ b/Dockerfile-listener.rhel7
@@ -8,12 +8,13 @@ RUN yum -y update \
 ENV APPBASEDIR=/listener
 
 ADD scl-enable.sh $APPBASEDIR/
+ADD requirements-listener.txt $APPBASEDIR/
 
 RUN adduser --gid 0 -d $APPBASEDIR --no-create-home -c 'Red Hat Insights' insights
 
 RUN $APPBASEDIR/scl-enable.sh pip install --upgrade pip
 
-RUN $APPBASEDIR/scl-enable.sh pip install psycopg2-binary requests insights-core prometheus_client "aiokafka==0.5.0"
+RUN $APPBASEDIR/scl-enable.sh pip install -r $APPBASEDIR/requirements-listener.txt
 
 ADD $APPBASEDIR/*.sh $APPBASEDIR/
 ADD $APPBASEDIR/*.py $APPBASEDIR/listener/

--- a/Dockerfile-manager
+++ b/Dockerfile-manager
@@ -9,11 +9,11 @@ ENV APPBASEDIR=/manager
 ENV INSIGHTS_VULNERABILITY_VERSION=latest
 
 ADD scl-enable.sh $APPBASEDIR/
+ADD requirements-manager.txt $APPBASEDIR/
 
 RUN $APPBASEDIR/scl-enable.sh pip install --upgrade pip
 
-RUN $APPBASEDIR/scl-enable.sh pip install psycopg2-binary tornado requests \
-         PyYAML python-dateutil prometheus_client peewee
+RUN $APPBASEDIR/scl-enable.sh pip install -r $APPBASEDIR/requirements-manager.txt
 
 ADD $APPBASEDIR/entrypoint.sh $APPBASEDIR/
 ADD $APPBASEDIR/*.py $APPBASEDIR/manager/

--- a/Dockerfile-manager.rhel7
+++ b/Dockerfile-manager.rhel7
@@ -9,11 +9,11 @@ ENV APPBASEDIR=/manager
 ENV INSIGHTS_VULNERABILITY_VERSION=latest
 
 ADD scl-enable.sh $APPBASEDIR/
+ADD requirements-manager.txt $APPBASEDIR/
 
 RUN $APPBASEDIR/scl-enable.sh pip install --upgrade pip
 
-RUN $APPBASEDIR/scl-enable.sh pip install psycopg2-binary tornado requests \
-         PyYAML python-dateutil prometheus_client peewee
+RUN $APPBASEDIR/scl-enable.sh pip install -r $APPBASEDIR/requirements-manager.txt
 
 ADD $APPBASEDIR/entrypoint.sh $APPBASEDIR/
 ADD $APPBASEDIR/*.py $APPBASEDIR/manager/

--- a/Dockerfile-vmaas-sync
+++ b/Dockerfile-vmaas-sync
@@ -8,12 +8,13 @@ RUN yum -y update \
 ENV APPBASEDIR=/vmaas_sync
 
 ADD scl-enable.sh $APPBASEDIR/
+ADD requirements-vmaas-sync.txt $APPBASEDIR/
 
 RUN adduser --gid 0 -d $APPBASEDIR --no-create-home -c 'Red Hat Insights' insights
 
 RUN $APPBASEDIR/scl-enable.sh pip install --upgrade pip
 
-RUN $APPBASEDIR/scl-enable.sh pip install tornado prometheus_client "aiokafka==0.5.0" psycopg2-binary requests
+RUN $APPBASEDIR/scl-enable.sh pip install -r $APPBASEDIR/requirements-vmaas-sync.txt
 
 ADD $APPBASEDIR/*.sh $APPBASEDIR/
 ADD $APPBASEDIR/*.py $APPBASEDIR/vmaas_sync/

--- a/Dockerfile-vmaas-sync.rhel7
+++ b/Dockerfile-vmaas-sync.rhel7
@@ -8,12 +8,13 @@ RUN yum -y update \
 ENV APPBASEDIR=/vmaas_sync
 
 ADD scl-enable.sh $APPBASEDIR/
+ADD requirements-vmaas-sync.txt $APPBASEDIR/
 
 RUN adduser --gid 0 -d $APPBASEDIR --no-create-home -c 'Red Hat Insights' insights
 
 RUN $APPBASEDIR/scl-enable.sh pip install --upgrade pip
 
-RUN $APPBASEDIR/scl-enable.sh pip install tornado prometheus_client "aiokafka==0.5.0" psycopg2-binary requests
+RUN $APPBASEDIR/scl-enable.sh pip install -r $APPBASEDIR/requirements-vmaas-sync.txt
 
 ADD $APPBASEDIR/*.sh $APPBASEDIR/
 ADD $APPBASEDIR/*.py $APPBASEDIR/vmaas_sync/

--- a/requirements-evaluator.txt
+++ b/requirements-evaluator.txt
@@ -1,0 +1,9 @@
+aiokafka==0.5.0
+certifi==2019.3.9
+chardet==3.0.4
+idna==2.8
+kafka-python==1.4.3
+prometheus_client==0.6.0
+psycopg2-binary==2.8.1
+requests==2.21.0
+urllib3==1.24.1

--- a/requirements-listener.txt
+++ b/requirements-listener.txt
@@ -1,0 +1,16 @@
+aiokafka==0.5.0
+cachecontrol==0.12.5
+certifi==2019.3.9
+chardet==3.0.4
+idna==2.8
+insights-core==3.0.88
+kafka-python==1.4.3
+lockfile==0.12.2
+msgpack==0.6.1
+prometheus_client==0.6.0
+psycopg2-binary==2.8.1
+pyyaml==3.13
+redis==3.2.1
+requests==2.21.0
+six==1.12.0
+urllib3==1.24.1

--- a/requirements-manager.txt
+++ b/requirements-manager.txt
@@ -1,0 +1,12 @@
+PyYAML==5.1
+certifi==2019.3.9
+chardet==3.0.4
+idna==2.8
+peewee==3.9.3
+prometheus-client==0.6.0
+psycopg2-binary==2.8.1
+python-dateutil==2.8.0
+requests==2.21.0
+six==1.12.0
+tornado==6.0.2
+urllib3==1.24.1

--- a/requirements-vmaas-sync.txt
+++ b/requirements-vmaas-sync.txt
@@ -1,0 +1,10 @@
+aiokafka==0.5.0
+certifi==2019.3.9
+chardet==3.0.4
+idna==2.8
+kafka-python==1.4.3
+prometheus-client==0.6.0
+psycopg2-binary==2.8.1
+requests==2.21.0
+tornado==6.0.2
+urllib3==1.24.1


### PR DESCRIPTION
Dockerfiles modified to pip install from requirements-xxx.txt files where xxx is component.  These requirements file specify explicitly the versions of the python libs to be installed.

Previously we would install libraries that resulted in several dependencies getting installed as well.  All the dependencies have been added to the requirements file with specific versions as well.