### PR TITLE
Revert "only evaluate latest version of each package"

### DIFF
--- a/listener/archive_parser.py
+++ b/listener/archive_parser.py
@@ -58,10 +58,10 @@ class ArchiveParser:
 
             if Installed in broker:
                 pkglist = broker[Installed]
-                for pkg_name in pkglist.packages:
-                    pkg = pkglist.get_max(pkg_name)
-                    self.package_list.append("%s-%s:%s-%s.%s" % (
-                        pkg.name, pkg.epoch, pkg.version, pkg.release, pkg.arch))
+                for pkgs_by_name in pkglist.packages.values():
+                    for pkg in pkgs_by_name:
+                        self.package_list.append("%s-%s:%s-%s.%s" % (
+                            pkg.name, pkg.epoch, pkg.version, pkg.release, pkg.arch))
             else:
                 RPMDB_PARSE_FAILURE.inc()
                 LOGGER.error("Unable to parse package list from archive.")


### PR DESCRIPTION
This reverts commit 3bda28dfa8c08f09284408d1171ff447fb53f90c.

Due to bug in insights-core get_max function.