### PR TITLE
VMAAS-442 - Make upload-listener more resilient in the face of archiv…

### DIFF
--- a/conf/listener.env
+++ b/conf/listener.env
@@ -6,3 +6,4 @@ KAFKA_GROUP_ID=vulnerability
 MESSAGE_TOPIC=vulnerability.evaluator.requests
 UPLOAD_TOPIC=platform.upload.available
 PROMETHEUS_PORT=8086
+MAX_ARCHIVE_RETRIES=2

--- a/listener/upload_listener.py
+++ b/listener/upload_listener.py
@@ -108,11 +108,11 @@ def main():
                     # on last try, log and fail this upload. Else, log try again
                     if (tries+1) == MAX_ARCHIVE_RETRIES:
                         ARCHIVE_RETRIEVE_FAILURE.inc()
-                        LOGGER.exception("Unable to retrieve archive")
+                        LOGGER.exception("Unable to retrieve archive: ")
                         return
 
                     ARCHIVE_RETRIEVE_ATTEMPT.inc()
-                    LOGGER.exception("Unable to retrieve archive, retrying...")
+                    LOGGER.exception("Unable to retrieve archive, retrying:")
 
             parser = ArchiveParser(tmp_file.name)
             try:

--- a/listener/upload_listener.py
+++ b/listener/upload_listener.py
@@ -16,12 +16,16 @@ from .archive_parser import ArchiveParser
 LOGGER = get_logger(__name__)
 
 PROMETHEUS_PORT = os.getenv('PROMETHEUS_PORT', '8086')
+# How many times are we willing to try to grab an uploaded archive before moving on?
+MAX_ARCHIVE_RETRIES = int(os.getenv('MAX_ARCHIVE_RETRIES', '2'))
 
 NEW_SYSTEM = Counter('ve_listener_upl_new_system', '# of new systems inserted')
 UPDATE_SYSTEM = Counter('ve_listener_upl_update_system', '# of systems updated')
 PROCESS_UPLOAD = Counter('ve_listener_upl_uploads_processed', '# of uploaded archives processed')
 MISSING_ID = Counter('ve_listener_upl_missing_inventory_id', '# of upload-msgs missing inventory_id')
-ARCHIVE_PARSE_FAILURE = Counter('ve_listener_upl_archive_excpetions', '# of exceptions during archive-processing')
+ARCHIVE_PARSE_FAILURE = Counter('ve_listener_upl_archive_exceptions', '# of exceptions during archive-processing')
+ARCHIVE_RETRIEVE_ATTEMPT = Counter('ve_listener_upl_archive_tgz_attempt', '# of times retried archive-retrieval')
+ARCHIVE_RETRIEVE_FAILURE = Counter('ve_listener_upl_archive_tgz_failure', '# of times gave up on archive retrieval')
 ARCHIVE_NO_RPMDB = Counter('ve_listener_upl_no_rpmdb', '# of systems ignored due to missing rpmdb')
 
 
@@ -90,11 +94,26 @@ def main():
         # Download archive an parse
         with tempfile.NamedTemporaryFile(delete=True) as tmp_file:
             LOGGER.debug("Writing temp file to %s", tmp_file.name)
-            response = session.get(upload_data["url"], stream=True, allow_redirects=True)
-            for chunk in response.iter_content(chunk_size=1024):
-                if chunk:  # filter out keep-alive new chunks
-                    tmp_file.write(chunk)
-            tmp_file.flush()
+            # Grab the uploaded archive and write it locally so we can dig Important THings out of it
+            # If the read-attempt fails, retry up to MAX_ARCHIVE_RETRIES times before logging the failure and moving on
+            for tries in range(MAX_ARCHIVE_RETRIES):
+                try:
+                    response = session.get(upload_data["url"], stream=True, allow_redirects=True)
+                    for chunk in response.iter_content(chunk_size=1024):
+                        if chunk:  # filter out keep-alive new chunks
+                            tmp_file.write(chunk)
+                    tmp_file.flush()
+                    break
+                except Exception: # pylint: disable=broad-except
+                    # on last try, log and fail this upload. Else, log try again
+                    if (tries+1) == MAX_ARCHIVE_RETRIES:
+                        ARCHIVE_RETRIEVE_FAILURE.inc()
+                        LOGGER.exception("Unable to retrieve archive")
+                        return
+
+                    ARCHIVE_RETRIEVE_ATTEMPT.inc()
+                    LOGGER.exception("Unable to retrieve archive, retrying...")
+
             parser = ArchiveParser(tmp_file.name)
             try:
                 parser.parse()

--- a/listener/upload_listener.py
+++ b/listener/upload_listener.py
@@ -112,7 +112,7 @@ def main():
                         return
 
                     ARCHIVE_RETRIEVE_ATTEMPT.inc()
-                    LOGGER.exception("Unable to retrieve archive, retrying:")
+                    LOGGER.exception("Unable to retrieve archive, retrying: ")
 
             parser = ArchiveParser(tmp_file.name)
             try:


### PR DESCRIPTION
…e-access-failures

* Add env-var MAX_ARCHIVE_RETRIES, for # of times we will attempt to access a given tgz. Default is '2'
* Log and count *any* exception while attempting tgz-retrieval
* Upon hitting max, log/count as a different error, drop this archive and move on