### PR TITLE
Make listener selective about giving work to evaluator

### DIFF
--- a/listener/upload_listener.py
+++ b/listener/upload_listener.py
@@ -8,11 +8,11 @@ import json
 import os
 import signal
 import tempfile
-import pytz
 
 from psycopg2 import DatabaseError
 from prometheus_client import Counter, start_http_server
 import requests
+import pytz
 
 from common import mqueue
 from common.database_handler import DatabaseHandler, init_db

--- a/listener/upload_listener.py
+++ b/listener/upload_listener.py
@@ -2,11 +2,13 @@
 
 import asyncio
 from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime
 import hashlib
 import json
 import os
 import signal
 import tempfile
+import pytz
 
 from psycopg2 import DatabaseError
 from prometheus_client import Counter, start_http_server
@@ -28,6 +30,7 @@ WORKER_THREADS = int(os.getenv('WORKER_THREADS', '30'))
 # prometheus metrics
 NEW_SYSTEM = Counter('ve_listener_upl_new_system', '# of new systems inserted')
 UPDATE_SYSTEM = Counter('ve_listener_upl_update_system', '# of systems updated')
+UNCHANGED_SYSTEM = Counter('ve_listener_upl_unchanged_system', '# of system-updates with same vmaas info')
 PROCESS_UPLOAD = Counter('ve_listener_upl_uploads_processed', '# of uploaded archives processed')
 MISSING_ID = Counter('ve_listener_upl_missing_inventory_id', '# of upload-msgs missing inventory_id')
 ARCHIVE_PARSE_FAILURE = Counter('ve_listener_upl_archive_exceptions', '# of exceptions during archive-processing')
@@ -69,34 +72,41 @@ def format_vmaas_request(package_list, repo_list=None, modules_list=None):
 
 
 def db_import_system(conn, inventory_id, rh_account, s3_url, vmaas_json, satellite_managed):
-    """Import initial system record to the DB."""
-    # TODO: json_checksum
-    inserted = False
-    updated = False
-    json_checksum = hashlib.sha256(vmaas_json.encode('utf-8')).hexdigest()
+    """Import initial system record to the DB, report back on what we did."""
+
+    rtrn = {'inserted': False, 'updated': False, 'changed': False, 'failed': True}
+
     with conn.cursor() as cur:
         try:
+            unchanged_since = None
+            json_checksum = hashlib.sha256(vmaas_json.encode('utf-8')).hexdigest()
+            curr_time = datetime.now(tz=pytz.utc)
             # xmax is PG system column used to find out if row was inserted or updated
             cur.execute("""INSERT INTO system_platform
                         (inventory_id, rh_account, s3_url, vmaas_json, json_checksum, satellite_managed)
                         VALUES (%s, %s, %s, %s, %s, %s)
                         ON CONFLICT (inventory_id) DO UPDATE SET
                         rh_account = %s, s3_url = %s, vmaas_json = %s, json_checksum = %s, satellite_managed = %s
-                        RETURNING (xmax = 0) AS inserted
+                        RETURNING (xmax = 0) AS inserted, unchanged_since
                         """,
-                        (inventory_id, rh_account, s3_url, vmaas_json, '0', satellite_managed,
+                        (inventory_id, rh_account, s3_url, vmaas_json, json_checksum, satellite_managed,
                          rh_account, s3_url, vmaas_json, json_checksum, satellite_managed,))
-            inserted, = cur.fetchone()
+            rtrn['inserted'], unchanged_since = cur.fetchone()
             conn.commit()
-            if inserted:
+
+            # If inserting, or if unchanged_since is newer-than 'now', we want to evaluate this upload
+            rtrn['changed'] = rtrn['inserted'] or (unchanged_since > curr_time)
+
+            if rtrn['inserted']:
                 NEW_SYSTEM.inc()
             else:
-                updated = True
+                rtrn['updated'] = True
                 UPDATE_SYSTEM.inc()
+            rtrn['failed'] = False
         except DatabaseError:
             LOGGER.exception("Error importing system: ")
             conn.rollback()
-        return (inserted, updated)
+        return rtrn
 
 
 def download_archive(url, tmp_file, session):
@@ -153,16 +163,22 @@ def parse_archive(upload_data, session):
 
 
 def process_upload(upload_data, session, conn, loop=None):
-    """Parse archive and store it."""
+    """Parse archive and store it, ASSUMING vmaas-json has changed."""
     vmaas_request = parse_archive(upload_data, session)
+    sent = False
     if vmaas_request:
-        db_import_system(conn, upload_data["id"], upload_data["rh_account"], upload_data["url"],
-                         vmaas_request, upload_data.get("satellite_managed", False))
-        new_upload_msg = {"type": "upload_new_file", "system_id": upload_data["id"]}
-        EVALUATOR_QUEUE.send(new_upload_msg, loop=loop)
-        LOGGER.info('Sent message to topic %s: %s', mqueue.EVALUATOR_TOPIC,
-                    json.dumps(new_upload_msg).encode("utf8"))
-
+        rtrn = db_import_system(conn, upload_data["id"], upload_data["rh_account"], upload_data["url"],
+                                vmaas_request, upload_data.get("satellite_managed", False))
+        # only give evaluator work if the system's vmaas-call has changed since the last time we did this
+        if rtrn['changed']:
+            new_upload_msg = {"type": "upload_new_file", "system_id": upload_data["id"]}
+            EVALUATOR_QUEUE.send(new_upload_msg, loop=loop)
+            LOGGER.info('Sent message to topic %s: %s', mqueue.EVALUATOR_TOPIC,
+                        json.dumps(new_upload_msg).encode("utf8"))
+            sent = True
+        else:
+            UNCHANGED_SYSTEM.inc()
+    return sent
 
 def main():
     """Main kafka listener entrypoint."""

--- a/requirements-listener.txt
+++ b/requirements-listener.txt
@@ -9,6 +9,7 @@ lockfile==0.12.2
 msgpack==0.6.1
 prometheus_client==0.6.0
 psycopg2-binary==2.8.1
+pytz==2019.1
 pyyaml==3.13
 redis==3.2.1
 requests==2.21.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ pytest-cov
 pytest-flask
 python-box
 python-dateutil
+pytz
 PyYAML
 requests
 schema

--- a/tests/listener_tests/test_upload_listener.py
+++ b/tests/listener_tests/test_upload_listener.py
@@ -3,7 +3,12 @@
 """
 Unit tests for listener module
 """
-from listener.upload_listener import format_vmaas_request, db_import_system
+from time import sleep
+import logging
+
+import listener.upload_listener
+from listener.upload_listener import format_vmaas_request, db_import_system, process_upload, LOGGER
+from common.mqueue import MQWriter
 
 # We should refactor upload_listener to be a class where db and other things
 # are initialized in __init__() method.  This would allow us to override
@@ -31,13 +36,59 @@ class TestUploadListner:
     def test_import_system(self, pg_db_conn):
         """Test importing a system not-in-the-db, followed by same so it's-already-there"""
         # new system
-        (inserted, updated) = db_import_system(pg_db_conn, A_SYSTEM['inv-id'], A_SYSTEM['rh-acct'], A_SYSTEM['s3-url'],
-                                               A_SYSTEM['vmaas-json'], A_SYSTEM['managed'])
-        assert inserted
-        assert not updated
+        rtrn = db_import_system(pg_db_conn, A_SYSTEM['inv-id'], A_SYSTEM['rh-acct'], A_SYSTEM['s3-url'],
+                                A_SYSTEM['vmaas-json'], A_SYSTEM['managed'])
+        assert rtrn['inserted']
+        assert rtrn['changed']
+        assert not rtrn['updated']
+        sleep(2)
 
-        # And now it's an update
-        (inserted, updated) = db_import_system(pg_db_conn, A_SYSTEM['inv-id'], A_SYSTEM['rh-acct'], A_SYSTEM['s3-url'],
-                                               A_SYSTEM['vmaas-json'], A_SYSTEM['managed'])
-        assert not inserted
-        assert updated
+        # And now it's an rtrn['updated'], but same json
+        rtrn = db_import_system(pg_db_conn, A_SYSTEM['inv-id'], A_SYSTEM['rh-acct'], A_SYSTEM['s3-url'],
+                                A_SYSTEM['vmaas-json'], A_SYSTEM['managed'])
+        assert not rtrn['inserted']
+        assert rtrn['updated']
+        assert not rtrn['changed']
+        sleep(2)
+
+        # And now it's another rtrn['updated'], same json
+        rtrn = db_import_system(pg_db_conn, A_SYSTEM['inv-id'], A_SYSTEM['rh-acct'], A_SYSTEM['s3-url'],
+                                A_SYSTEM['vmaas-json'], A_SYSTEM['managed'])
+        assert not rtrn['inserted']
+        assert rtrn['updated']
+        assert not rtrn['changed']
+        sleep(2)
+
+        # And now it's an rtrn['updated'], with diff json
+        rtrn = db_import_system(pg_db_conn, A_SYSTEM['inv-id'], A_SYSTEM['rh-acct'], A_SYSTEM['s3-url'],
+                                A_SYSTEM['vmaas-json'] + '-1', A_SYSTEM['managed'])
+        assert not rtrn['inserted']
+        assert rtrn['updated']
+        assert rtrn['changed']
+
+    def test_process_upload(self, pg_db_conn, monkeypatch, caplog):
+        """Test to see that upload only sends eval-msgs on new systems and ones with new vmaas_json"""
+        same_json = "{'diff': False}"
+        diff_json = "{'diff': True}"
+        upld_data = {'id': 'A-SYSTEM-ID', 'rh_account': 'AN-ACCOUNT', 'url': 'A-URL', 'satellite_managed': False}
+        monkeypatch.setattr(MQWriter, 'send', lambda self, msg, loop: LOGGER.info('SENT'))
+        monkeypatch.setattr(listener.upload_listener, 'parse_archive', lambda upld_dta, sess: same_json)
+
+        # first-upload - should send
+        caplog.clear()
+        with caplog.at_level(logging.INFO):
+            process_upload(upld_data, None, pg_db_conn, None)
+        assert caplog.records[0].msg == 'SENT'
+
+        # re-upload - should not send
+        caplog.clear()
+        with caplog.at_level(logging.INFO):
+            process_upload(upld_data, None, pg_db_conn, None)
+        assert not caplog.records
+
+        # same-id, diff-vmaas upload - should send
+        monkeypatch.setattr(listener.upload_listener, 'parse_archive', lambda upld_dta, sess: diff_json)
+        caplog.clear()
+        with caplog.at_level(logging.INFO):
+            process_upload(upld_data, None, pg_db_conn, None)
+        assert caplog.records[0].msg == 'SENT'


### PR DESCRIPTION
Listener should only send eval-messages on new systems or systems whose
vmaas_json is different than the last time we saw them.