### PR TITLE
change to named cursor when querying db for systems to reevaluate

### DIFF
--- a/vmaas_sync/vmaas_sync.py
+++ b/vmaas_sync/vmaas_sync.py
@@ -9,7 +9,7 @@ from tornado.ioloop import IOLoop, PeriodicCallback
 from tornado.web import Application, RequestHandler
 from tornado.websocket import websocket_connect
 
-from common.database_handler import DatabaseHandler, init_db
+from common.database_handler import DatabaseHandler, NamedCursor, init_db
 from common.logging import init_logging, get_logger
 from common import mqueue
 from common.utils import vmaas_post_request
@@ -190,13 +190,13 @@ class ServerApplication(Application):
         """Schedule re-evaluation for all systems in DB."""
         LOGGER.info("Re-evaluating all systems")
         conn = DatabaseHandler.get_connection()
-        cur = conn.cursor()
-        cur.execute("select inventory_id from system_platform")
-        # reevaluate updates for every system in the DB
-        for inventory_id, in cur.fetchall():
-            self.evaluator_queue.send({"type": "re-evaluate_system", "system_id": inventory_id})
-        cur.close()
+        with NamedCursor(conn) as cur:
+            cur.execute("select inventory_id from system_platform")
+            # reevaluate updates for every system in the DB
+            for inventory_id, in cur:
+                self.evaluator_queue.send({"type": "re-evaluate_system", "system_id": inventory_id})
         conn.commit()
+        DatabaseHandler.close_connection()
 
     def _read_websocket_message(self, message):
         """Read incoming websocket messages."""


### PR DESCRIPTION
This addresses VMAAS-457 and also ensures a new connection will be established following each time vmaas-sync checks for systems that need to be re-evaluated.