### PR TITLE
Add x-methodName to apiSpec

### DIFF
--- a/manager.spec.yaml
+++ b/manager.spec.yaml
@@ -9,6 +9,7 @@ paths:
       summary: Application version
       description: Get application version.
       operationId: manager.main.version
+      x-methodName: getVersion
       responses:
         200:
           description: Application version.
@@ -25,6 +26,7 @@ paths:
       summary: Details of a CVE.
       description: Show all information about given CVE.
       operationId: manager.cve_handler.GetCves.get
+      x-methodName: getCveDetail
       security:
         - ApiKeyAuth: []
         - BasicAuth: []
@@ -49,6 +51,7 @@ paths:
       summary: Details of a CVE.
       description: Show all information about given CVE.
       operationId: manager.cve_handler.GetCvesDetails.get
+      x-methodName: getCveDetails
       security:
         - ApiKeyAuth: []
         - BasicAuth: []
@@ -73,6 +76,7 @@ paths:
       summary: Affected systems for a given CVE.
       description: Report of affected systems for a given CVE.
       operationId: manager.cve_handler.GetCvesAffectedSystems.get
+      x-methodName: getAffectedSystemsByCve
       security:
         - ApiKeyAuth: []
         - BasicAuth: []
@@ -105,6 +109,7 @@ paths:
       summary: Available status/status_id pairs.
       description: Returns available status and status_id pairs where status_id is internal ID of the status.
       operationId: manager.status_handler.GetStatus.get
+      x-methodName: getStatusList
       security:
         - ApiKeyAuth: []
         - BasicAuth: []
@@ -119,6 +124,7 @@ paths:
       summary: Set status for system vulnerability.
       description: Sets status for given host and CVE.
       operationId: manager.status_handler.PatchStatus.patch
+      x-methodName: setStatus
       security:
         - ApiKeyAuth: []
         - BasicAuth: []
@@ -151,6 +157,7 @@ paths:
       summary: List systems.
       description: List systems visible to logged in account with basic information related to vulnerabilities.
       operationId: manager.system_handler.GetSystems.get
+      x-methodName: getSystemsList
       security:
         - ApiKeyAuth: []
         - BasicAuth: []
@@ -181,6 +188,7 @@ paths:
       summary: CVE report for a system.
       description: Shows detailed infomation about all CVEs the system is exposed to.
       operationId: manager.system_handler.GetSystemsCves.get
+      x-methodName: getCveListBySystem
       security:
         - ApiKeyAuth: []
         - BasicAuth: []
@@ -218,6 +226,7 @@ paths:
       summary: Opt in/out a system to/from vulnerability application.
       description: Opts in/out a systems. Opted out system is not shown and manageable by the vulnerability application.
       operationId: manager.system_handler.PatchSystemsOptOut.patch
+      x-methodName: setSystemOptOut
       security:
         - ApiKeyAuth: []
         - BasicAuth: []
@@ -251,6 +260,7 @@ paths:
       summary: Vulnerabilities overview.
       description: Overview of vulnerabilities across whole host inventory.
       operationId: manager.vulnerabilities_handler.GetCves.get
+      x-methodName: getCveList
       security:
         - ApiKeyAuth: []
         - BasicAuth: []


### PR DESCRIPTION
Adds x-methodName to api spec. This is then used by @redhat-cloud-services/vulnerabilities-client as a name of a method.