### PR TITLE
Add repo and system_repo tables

### DIFF
--- a/database/schema/upgrade_scripts/010-add-repo-tables.sql
+++ b/database/schema/upgrade_scripts/010-add-repo-tables.sql
@@ -1,0 +1,43 @@
+-- repo
+CREATE TABLE repo (
+  id SERIAL,
+  name TEXT NOT NULL UNIQUE, CHECK (NOT empty(name)),
+  PRIMARY KEY (id)
+) TABLESPACE pg_default;
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON repo TO ve_db_user_listener;
+
+-- system_repo
+CREATE TABLE system_repo (
+  inventory_id TEXT NOT NULL, CHECK (NOT empty(inventory_id)),
+  repo_id INT NOT NULL,
+  UNIQUE (inventory_id, repo_id),
+  CONSTRAINT inventory_id
+    FOREIGN KEY (inventory_id)
+    REFERENCES system_platform (inventory_id),
+  CONSTRAINT repo_id
+    FOREIGN KEY (repo_id)
+    REFERENCES repo (id)
+) TABLESPACE pg_default;
+
+CREATE INDEX ON system_repo(inventory_id);
+CREATE INDEX ON system_repo(repo_id);
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON system_repo TO ve_db_user_listener;
+
+-- user for evaluator component
+GRANT SELECT ON repo TO ve_db_user_evaluator;
+GRANT SELECT ON system_repo TO ve_db_user_evaluator;
+GRANT USAGE, SELECT ON repo_id_seq TO ve_db_user_evaluator;
+
+-- user for listener component
+GRANT SELECT ON repo TO ve_db_user_listener;
+GRANT SELECT ON system_repo TO ve_db_user_listener;
+GRANT USAGE, SELECT ON repo_id_seq TO ve_db_user_listener;
+
+-- user for UI manager component
+GRANT SELECT ON repo TO ve_db_user_manager;
+GRANT SELECT ON system_repo TO ve_db_user_manager;
+
+GRANT SELECT ON repo TO ve_db_user_vmaas_sync;
+GRANT SELECT ON system_repo TO ve_db_user_vmaas_sync;

--- a/database/schema/ve_db_postgresql.sql
+++ b/database/schema/ve_db_postgresql.sql
@@ -30,7 +30,7 @@ CREATE TABLE IF NOT EXISTS db_version (
 ) TABLESPACE pg_default;
 
 -- set the schema version directly in the insert statement here!!
-INSERT INTO db_version (name, version) VALUES ('schema_version', 9);
+INSERT INTO db_version (name, version) VALUES ('schema_version', 10);
 -- INSERT INTO db_version (name, version) VALUES ('schema_version', :schema_version);
 
 
@@ -578,6 +578,35 @@ CREATE TABLE IF NOT EXISTS deleted_systems (
 CREATE INDEX ON deleted_systems(when_deleted);
 
 GRANT SELECT, INSERT, UPDATE, DELETE ON deleted_systems TO ve_db_user_listener;
+
+
+-- repo
+CREATE TABLE IF NOT EXISTS repo (
+  id SERIAL,
+  name TEXT NOT NULL UNIQUE, CHECK (NOT empty(name)),
+  PRIMARY KEY (id)
+) TABLESPACE pg_default;
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON repo TO ve_db_user_listener;
+
+
+-- system_repo
+CREATE TABLE IF NOT EXISTS system_repo (
+  inventory_id TEXT NOT NULL, CHECK (NOT empty(inventory_id)),
+  repo_id INT NOT NULL,
+  UNIQUE (inventory_id, repo_id),
+  CONSTRAINT inventory_id
+    FOREIGN KEY (inventory_id)
+    REFERENCES system_platform (inventory_id),
+  CONSTRAINT repo_id
+    FOREIGN KEY (repo_id)
+    REFERENCES repo (id)
+) TABLESPACE pg_default;
+
+CREATE INDEX ON system_repo(inventory_id);
+CREATE INDEX ON system_repo(repo_id);
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON system_repo TO ve_db_user_listener;
 
 -- ----------------------------------------------------------------------------
 -- Read access for all users

--- a/listener/upload_listener.py
+++ b/listener/upload_listener.py
@@ -8,8 +8,10 @@ import os
 import signal
 import tempfile
 from distutils.util import strtobool  # pylint: disable=import-error, no-name-in-module
+import flags
 
 from psycopg2 import DatabaseError
+from psycopg2.extras import execute_values
 from prometheus_client import Counter, start_http_server
 import requests
 import pytz
@@ -50,10 +52,23 @@ ARCHIVE_RETRIEVE_INVALID_HTTP = Counter('ve_listener_upl_archive_tgz_invalid_htt
                                         '# archive downloaded with invalid http code')
 ARCHIVE_NO_RPMDB = Counter('ve_listener_upl_no_rpmdb', '# of systems ignored due to missing rpmdb')
 MESSAGE_PARSE_ERROR = Counter('ve_listener_message_parse_error', '# of message parse errors')
+NEW_REPO = Counter('ve_listener_upl_new_repo', '# of new repos inserted')
+NEW_SYSTEM_REPO = Counter('ve_listener_upl_new_system_repo', '# of new system_repo pairs inserted')
+DELETED_REPO = Counter('ve_listener_upl_repo_deleted', '# deleted repos')
+DELETED_SYSTEM_REPO = Counter('ve_listener_upl_system_repo_deleted', '# deleted system_repo pairs')
 
 # kafka clients
 LISTENER_QUEUE = mqueue.MQReader([mqueue.UPLOAD_TOPIC, mqueue.EVENTS_TOPIC])
 EVALUATOR_QUEUE = mqueue.MQWriter(mqueue.EVALUATOR_TOPIC)
+
+
+class ImportStatus(flags.Flags):
+    """Import to database status."""
+
+    INSERTED = 1
+    CHANGED = 2
+    UPDATED = 4
+    FAILED = 8
 
 
 async def terminate(_, loop):
@@ -82,52 +97,131 @@ def format_vmaas_request(package_list, repo_list=None, modules_list=None):
     return json.dumps(vmaas_request)
 
 
-def db_import_system(inventory_id, rh_account, s3_url, vmaas_json, satellite_managed):
+def db_import_system(inventory_id: str, rh_account: str, s3_url: str, vmaas_json: str, satellite_managed: bool,
+                     repo_list: list):
     """Import initial system record to the DB, report back on what we did."""
 
-    rtrn = {'inserted': False, 'updated': False, 'changed': False, 'failed': True}
+    status = ImportStatus.FAILED
 
     with DatabasePoolConnection() as conn:
         with conn.cursor() as cur:
             try:
-                curr_time = datetime.now(tz=pytz.utc)
-                cur.execute("""SELECT inventory_id FROM deleted_systems WHERE inventory_id = %s
-                               AND when_deleted > %s
-                            """, (inventory_id, curr_time - timedelta(hours=SYSTEM_DELETION_THRESHOLD,)))
-                if cur.fetchone() is not None:
-                    LOGGER.warning('Received recently deleted inventory id: %s', inventory_id)
-                    DELETED_UPLOADED.inc()
-                    return rtrn
+                import_status = db_import_system_platform(cur, inventory_id, rh_account, s3_url, vmaas_json,
+                                                          satellite_managed)
+                if import_status is None:
+                    return status
+                status |= import_status
 
-                unchanged_since = None
-                json_checksum = hashlib.sha256(vmaas_json.encode('utf-8')).hexdigest()
-                # xmax is PG system column used to find out if row was inserted or updated
-                cur.execute("""INSERT INTO system_platform
-                            (inventory_id, rh_account, s3_url, vmaas_json, json_checksum, satellite_managed)
-                            VALUES (%s, %s, %s, %s, %s, %s)
-                            ON CONFLICT (inventory_id) DO UPDATE SET
-                            rh_account = %s, s3_url = %s, vmaas_json = %s, json_checksum = %s, satellite_managed = %s
-                            RETURNING (xmax = 0) AS inserted, unchanged_since
-                            """,
-                            (inventory_id, rh_account, s3_url, vmaas_json, json_checksum, satellite_managed,
-                             rh_account, s3_url, vmaas_json, json_checksum, satellite_managed,))
-                rtrn['inserted'], unchanged_since = cur.fetchone()
+                db_import_repos(cur, repo_list)
+                db_import_system_repos(cur, repo_list, inventory_id)
+
+                db_delete_other_system_repos(cur, repo_list, inventory_id)
+                db_delete_unused_repos(cur)
+
                 conn.commit()
 
-                # If inserting, or if unchanged_since is newer-than 'now', we want to evaluate this upload
-                rtrn['changed'] = rtrn['inserted'] or (unchanged_since > curr_time)
-
-                if rtrn['inserted']:
-                    NEW_SYSTEM.inc()
-                else:
-                    rtrn['updated'] = True
-                    UPDATE_SYSTEM.inc()
-                rtrn['failed'] = False
+                status -= ImportStatus.FAILED
             except DatabaseError:
                 DATABASE_ERROR.inc()
                 LOGGER.exception("Error importing system: ")
                 conn.rollback()
-            return rtrn
+            return status
+
+
+def db_import_system_platform(cur, inventory_id: str, rh_account: str, s3_url: str, vmaas_json: str,
+                              satellite_managed: bool):
+    """Import system_platform item to db table."""
+
+    curr_time = datetime.now(tz=pytz.utc)
+    cur.execute("""select inventory_id from deleted_systems where inventory_id = %s and when_deleted > %s""",
+                (inventory_id, curr_time - timedelta(hours=SYSTEM_DELETION_THRESHOLD, )))
+    if cur.fetchone() is not None:
+        LOGGER.warning('Received recently deleted inventory id: %s', inventory_id)
+        DELETED_UPLOADED.inc()
+        return None
+
+    json_checksum = hashlib.sha256(vmaas_json.encode('utf-8')).hexdigest()
+    # xmax is PG system column used to find out if row was inserted or updated
+    cur.execute("""INSERT INTO system_platform
+                (inventory_id, rh_account, s3_url, vmaas_json, json_checksum, satellite_managed)
+                VALUES (%s, %s, %s, %s, %s, %s)
+                ON CONFLICT (inventory_id) DO UPDATE SET
+                rh_account = %s, s3_url = %s, vmaas_json = %s, json_checksum = %s, satellite_managed = %s
+                RETURNING (xmax = 0) AS inserted, unchanged_since""",
+                (inventory_id, rh_account, s3_url, vmaas_json, json_checksum, satellite_managed,
+                 rh_account, s3_url, vmaas_json, json_checksum, satellite_managed))
+    inserted, unchanged_since = cur.fetchone()
+    if inserted:
+        import_status = ImportStatus.INSERTED
+        NEW_SYSTEM.inc()
+    else:
+        import_status = ImportStatus.UPDATED
+        UPDATE_SYSTEM.inc()
+
+    if inserted or (unchanged_since > curr_time):
+        import_status |= ImportStatus.CHANGED
+    return import_status
+
+
+def db_import_system_repos(cur, repos: list, inventory_id: str):
+    """Import items to system_repo table."""
+
+    if repos:
+        cur.execute("""select id from repo where name in %s""", (tuple(repos), ))
+        to_insert = [(inventory_id, repo_id) for repo_id, *_ in cur.fetchall()]
+        if to_insert:
+            execute_values(cur, """insert into system_repo (inventory_id, repo_id) values %s
+                                   on conflict (inventory_id, repo_id) do nothing returning repo_id""",
+                           to_insert, page_size=len(to_insert))
+        repo_ids = [repo_id for repo_id, *_ in cur.fetchall()]
+        if repo_ids:
+            NEW_SYSTEM_REPO.inc(len(repo_ids))
+        return repo_ids
+    return None
+
+
+def db_delete_other_system_repos(cur, repos: list, inventory_id: str):
+    """Delete all system_repo items not including input repos."""
+
+    if repos:
+        cur.execute("""delete from system_repo sr
+                    where sr.inventory_id = %s and sr.repo_id not in
+                    (select repo.id from repo where repo.name in %s)
+                    returning sr.repo_id""", (inventory_id, tuple(repos)))
+    else:
+        cur.execute("""delete from system_repo where inventory_id = %s returning repo_id""",
+                    (inventory_id, ))
+    deleted_repo_ids = [repo_id for repo_id, *_ in cur.fetchall()]
+    if deleted_repo_ids:
+        DELETED_SYSTEM_REPO.inc(len(deleted_repo_ids))
+    return deleted_repo_ids
+
+
+def db_import_repos(cur, repos: list):
+    """Ensure input repos to be in repo db table."""
+
+    if repos:
+        to_insert = [(repo, ) for repo in repos]
+        execute_values(cur, """insert into repo (name) values %s on conflict (name) do nothing
+                               returning name""", to_insert, page_size=len(to_insert))
+        repo_names = [repo_name for repo_name, *_ in cur.fetchall()]
+        if repo_names:
+            NEW_REPO.inc(len(repo_names))
+        return repo_names
+    return None
+
+
+def db_delete_unused_repos(cur) -> list:
+    """Delete repos not related with any system."""
+
+    cur.execute("""delete from repo
+                   using repo ljr left join system_repo sr on sr.repo_id = ljr.id
+                   where ljr.id = repo.id and sr.inventory_id is null
+                   returning repo.name""")
+    delete_repo_names = [repo_name for repo_name, *_ in cur.fetchall()]
+    if delete_repo_names:
+        DELETED_REPO.inc(len(delete_repo_names))
+    return delete_repo_names
 
 
 def db_delete_system(inventory_id):
@@ -158,6 +252,9 @@ def db_delete_system(inventory_id):
                                 WHERE inventory_id = %s
                                 """, (inventory_id,))
                     cur.execute("""DELETE FROM system_vulnerabilities
+                                WHERE inventory_id = %s
+                                """, (inventory_id,))
+                    cur.execute("""DELETE FROM system_repo
                                 WHERE inventory_id = %s
                                 """, (inventory_id,))
                     cur.execute("""DELETE FROM system_platform
@@ -207,7 +304,7 @@ def download_archive(url, tmp_file):
 
 def parse_archive(upload_data):
     """Parse archive after it's downloaded."""
-    vmaas_request = None
+    vmaas_request, repo_list = None, None
     with tempfile.NamedTemporaryFile(delete=True) as tmp_file:
         if download_archive(upload_data["url"], tmp_file):
             parser = ArchiveParser(tmp_file.name)
@@ -217,28 +314,29 @@ def parse_archive(upload_data):
                     vmaas_request = format_vmaas_request(parser.package_list,
                                                          repo_list=parser.repo_list,
                                                          modules_list=parser.modules_list)
+                    repo_list = parser.repo_list
                 else:
                     ARCHIVE_NO_RPMDB.inc()
                     LOGGER.error("Unable to store system, empty package list.")
             except Exception:  # pylint: disable=broad-except
                 ARCHIVE_PARSE_FAILURE.inc()
                 LOGGER.exception("Unable to parse archive: ")
-    return vmaas_request
+    return vmaas_request, repo_list
 
 
 def process_upload(upload_data, loop=None):
     """Parse archive and store it, ASSUMING vmaas-json has changed."""
-    vmaas_request = parse_archive(upload_data)
+    vmaas_request, repo_list = parse_archive(upload_data)
     sent = False
     if vmaas_request:
         satellite_managed = upload_data.get("satellite_managed", False)
         # received satellite_managed value is None sometimes
         if not isinstance(satellite_managed, bool):
             satellite_managed = False
-        rtrn = db_import_system(upload_data["id"], upload_data["account"], upload_data["url"],
-                                vmaas_request, satellite_managed)
+        import_status = db_import_system(upload_data["id"], upload_data["account"], upload_data["url"],
+                                         vmaas_request, satellite_managed, repo_list)
         # only give evaluator work if the system's vmaas-call has changed since the last time we did this
-        if rtrn['changed'] or DISABLE_OPTIMISATION:
+        if ImportStatus.CHANGED in import_status or DISABLE_OPTIMISATION:
             new_upload_msg = {"type": "upload_new_file", "system_id": upload_data["id"]}
             EVALUATOR_QUEUE.send(new_upload_msg, loop=loop)
             LOGGER.info('Sent message to topic %s: %s', mqueue.EVALUATOR_TOPIC,

--- a/requirements-listener.txt
+++ b/requirements-listener.txt
@@ -16,3 +16,4 @@ requests==2.21.0
 six==1.12.0
 urllib3==1.24.3
 watchtower==0.5.5
+py-flags==1.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,4 @@ schema
 testing.postgresql
 tornado==6.0.2
 watchtower==0.5.5
+py-flags==1.1.2

--- a/tests/data/truncate_dev_data.sql
+++ b/tests/data/truncate_dev_data.sql
@@ -1,1 +1,1 @@
-TRUNCATE TABLE system_platform, cve_metadata, system_vulnerabilities, cve_affected_systems_cache, deleted_systems;
+TRUNCATE TABLE system_platform, cve_metadata, system_vulnerabilities, cve_affected_systems_cache, deleted_systems, repo, system_repo;

--- a/tests/listener_tests/test_upload_listener.py
+++ b/tests/listener_tests/test_upload_listener.py
@@ -3,6 +3,7 @@
 """
 Unit tests for listener module
 """
+
 import asyncio
 from concurrent.futures import ThreadPoolExecutor
 import os
@@ -14,7 +15,8 @@ import pytest
 import listener.upload_listener
 from listener.upload_listener import format_vmaas_request, db_import_system, process_upload, LOGGER, \
     terminate, LISTENER_QUEUE, EVALUATOR_QUEUE, on_thread_done, download_archive, parse_archive, \
-    db_delete_system, process_delete
+    db_delete_system, process_delete, ImportStatus, db_import_repos, db_import_system_repos, db_delete_unused_repos, \
+    db_delete_other_system_repos
 from common.database_handler import DatabasePool
 from common.mqueue import MQWriter
 
@@ -99,15 +101,15 @@ class TestUploadListner:
     def test_parse_archive_no_pkgs(self):
         """test_parse_archive_no_pkgs"""
         download_server_host = os.getenv("DOWNLOAD_SERVER_HOST")
-        vmaas_request = parse_archive({"url": "%s/api/v1/download/insights-archive-no-packages.tar.gz" %
-                                              download_server_host})
+        vmaas_request, _ = parse_archive({"url": "%s/api/v1/download/insights-archive-no-packages.tar.gz"
+                                                 % download_server_host})
         assert vmaas_request is None
 
     def test_parse_archive_exception(self):
         """test_parse_archive_exception"""
         download_server_host = os.getenv("DOWNLOAD_SERVER_HOST")
-        vmaas_request = parse_archive({"url": "%s/api/v1/download/non-archive.tar.gz" %
-                                              download_server_host})
+        vmaas_request, _ = parse_archive({"url": "%s/api/v1/download/non-archive.tar.gz"
+                                                 % download_server_host})
         assert vmaas_request is None
 
     def test_import_system(self, pg_db_conn, caplog):  # pylint: disable=unused-argument
@@ -115,36 +117,28 @@ class TestUploadListner:
         # new system
         with DatabasePool(1):
             rtrn = db_import_system(A_SYSTEM['inv-id'], A_SYSTEM['rh-acct'], A_SYSTEM['s3-url'],
-                                    A_SYSTEM['vmaas-json'], A_SYSTEM['managed'])
-            assert rtrn['inserted']
-            assert rtrn['changed']
-            assert not rtrn['updated']
+                                    A_SYSTEM['vmaas-json'], A_SYSTEM['managed'], [])
+            assert ImportStatus.INSERTED | ImportStatus.CHANGED == rtrn
 
             # And now it's an rtrn['updated'], but same json
             rtrn = db_import_system(A_SYSTEM['inv-id'], A_SYSTEM['rh-acct'], A_SYSTEM['s3-url'],
-                                    A_SYSTEM['vmaas-json'], A_SYSTEM['managed'])
-            assert not rtrn['inserted']
-            assert rtrn['updated']
-            assert not rtrn['changed']
+                                    A_SYSTEM['vmaas-json'], A_SYSTEM['managed'], [])
+            assert ImportStatus.UPDATED == rtrn
 
             # And now it's another rtrn['updated'], same json
             rtrn = db_import_system(A_SYSTEM['inv-id'], A_SYSTEM['rh-acct'], A_SYSTEM['s3-url'],
-                                    A_SYSTEM['vmaas-json'], A_SYSTEM['managed'])
-            assert not rtrn['inserted']
-            assert rtrn['updated']
-            assert not rtrn['changed']
+                                    A_SYSTEM['vmaas-json'], A_SYSTEM['managed'], [])
+            assert ImportStatus.UPDATED == rtrn
 
             # And now it's an rtrn['updated'], with diff json
             rtrn = db_import_system(A_SYSTEM['inv-id'], A_SYSTEM['rh-acct'], A_SYSTEM['s3-url'],
-                                    A_SYSTEM['vmaas-json'] + '-1', A_SYSTEM['managed'])
-            assert not rtrn['inserted']
-            assert rtrn['updated']
-            assert rtrn['changed']
+                                    A_SYSTEM['vmaas-json'] + '-1', A_SYSTEM['managed'], [])
+            assert ImportStatus.UPDATED | ImportStatus.CHANGED == rtrn
 
             # And try to import system with invalid inventory id
             with caplog.at_level(logging.ERROR):
-                rtrn = db_import_system(None, A_SYSTEM['rh-acct'], A_SYSTEM['s3-url'],
-                                        A_SYSTEM['vmaas-json'], A_SYSTEM['managed'])
+                db_import_system(None, A_SYSTEM['rh-acct'], A_SYSTEM['s3-url'],
+                                 A_SYSTEM['vmaas-json'], A_SYSTEM['managed'], [])
             assert caplog.records[0].msg.startswith("Error importing system:")
             caplog.clear()
 
@@ -156,7 +150,7 @@ class TestUploadListner:
         upld_data_no_satmanaged = {'id': 'B-SYSTEM-ID', 'account': 'AN-ACCOUNT',
                                    'url': 'A-URL', 'satellite_managed': None}
         monkeypatch.setattr(MQWriter, 'send', lambda self, msg, loop: LOGGER.info('SENT'))
-        monkeypatch.setattr(listener.upload_listener, 'parse_archive', lambda upld_dta: same_json)
+        monkeypatch.setattr(listener.upload_listener, 'parse_archive', lambda upld_dta: (same_json, []))
 
         with DatabasePool(1):
             # first-upload - should send
@@ -172,7 +166,7 @@ class TestUploadListner:
             assert not caplog.records
 
             # same-id, diff-vmaas upload - should send
-            monkeypatch.setattr(listener.upload_listener, 'parse_archive', lambda upld_dta: diff_json)
+            monkeypatch.setattr(listener.upload_listener, 'parse_archive', lambda upld_dta: (diff_json, None))
             caplog.clear()
             with caplog.at_level(logging.INFO):
                 process_upload(upld_data, None)
@@ -189,7 +183,7 @@ class TestUploadListner:
         with DatabasePool(1):
             # make sure system is in DB
             db_import_system(A_SYSTEM['inv-id'], A_SYSTEM['rh-acct'], A_SYSTEM['s3-url'],
-                             A_SYSTEM['vmaas-json'], A_SYSTEM['managed'])
+                             A_SYSTEM['vmaas-json'], A_SYSTEM['managed'], [])
 
             # now delete the system
             rtrn = db_delete_system(A_SYSTEM['inv-id'])
@@ -217,7 +211,7 @@ class TestUploadListner:
         with DatabasePool(1):
             # make sure system is in DB
             db_import_system(A_SYSTEM['inv-id'] + '1', A_SYSTEM['rh-acct'], A_SYSTEM['s3-url'],
-                             A_SYSTEM['vmaas-json'], A_SYSTEM['managed'])
+                             A_SYSTEM['vmaas-json'], A_SYSTEM['managed'], [])
 
             # delete the system
             with caplog.at_level(logging.INFO):
@@ -233,6 +227,81 @@ class TestUploadListner:
 
             with caplog.at_level(logging.WARNING):
                 db_import_system(A_SYSTEM['inv-id'] + '1', A_SYSTEM['rh-acct'], A_SYSTEM['s3-url'],
-                                 A_SYSTEM['vmaas-json'], A_SYSTEM['managed'])
+                                 A_SYSTEM['vmaas-json'], A_SYSTEM['managed'], [])
             assert caplog.records[0].msg.startswith('Received recently deleted inventory id:')
             caplog.clear()
+
+    @staticmethod
+    def _create_testing_system(cur, inventory_id: str):
+        cur.execute("""insert into system_platform
+                       (inventory_id, rh_account, s3_url, vmaas_json, json_checksum, satellite_managed)
+                       values (%s, 'acc', 'url', '{}', '0', true)""", (inventory_id,))
+
+    @staticmethod
+    def _clean_tmp_db_items(cur, inventory_ids: tuple):
+        cur.execute("""delete from system_repo""")
+        cur.execute("""delete from repo""")
+        cur.execute("""delete from system_platform where inventory_id in %s""", (inventory_ids,))
+
+    def test_import_repos(self, pg_db_conn):
+        """Test import repos to db. Ensure unique repos."""
+
+        cur = pg_db_conn.cursor()
+        self._clean_tmp_db_items(cur, ("s1",))
+        inserted = db_import_repos(cur, ["repo1", "repo2", "repo1"])
+        assert len(inserted) == 2
+        assert set(inserted) == {"repo1", "repo2"}
+
+        inserted = db_import_repos(cur, ["repo2", "repo3", "repo4"])
+        assert len(inserted) == 2
+        assert set(inserted) == {"repo3", "repo4"}
+
+        cur.execute("""select name from repo""")
+        rows = cur.fetchall()
+        assert len(rows) == 4
+        assert {"repo1", "repo2", "repo3", "repo4"} == {repo_name for repo_name, *_ in rows}
+        self._clean_tmp_db_items(cur, ("s1",))
+
+    def test_import_system_repos(self, pg_db_conn):
+        """Test import system_repo items to db."""
+
+        cur = pg_db_conn.cursor()
+        self._clean_tmp_db_items(cur, ("s1",))
+        repos = ["repo1", "repo2"]
+        db_import_repos(cur, repos)
+        self._create_testing_system(cur, "s1")
+        inserted = db_import_system_repos(cur, repos, "s1")
+        assert len(inserted) == 2
+        cur.execute("select inventory_id, repo.name from system_repo inner join repo on repo.id = repo_id")
+        rows = cur.fetchall()
+        assert len(rows) == 2
+        assert set(rows) == {("s1", "repo1"), ("s1", "repo2")}
+        self._clean_tmp_db_items(cur, ("s1",))
+
+    def test_delete_unused_repos(self, pg_db_conn):
+        """Test delete unused repo items."""
+
+        cur = pg_db_conn.cursor()
+        self._clean_tmp_db_items(cur, ("s1",))
+        repos = ["repo1", "repo2", "repo3", "repo4"]
+        inserted_repos = db_import_repos(cur, repos)
+        assert len(inserted_repos) == 4
+        self._create_testing_system(cur, "s1")
+        inserted = db_import_system_repos(cur, ["repo1", "repo2"], "s1")
+        assert len(inserted) == 2
+        deleted_repos = db_delete_unused_repos(cur)
+        assert set(deleted_repos) == {"repo3", "repo4"}
+
+    def test_delete_other_system_repos(self, pg_db_conn):
+        """Test delete not actual system_repo items."""
+
+        cur = pg_db_conn.cursor()
+        self._clean_tmp_db_items(cur, ("s1",))
+        repos = ["repo1", "repo2", "repo3"]
+        inserted_repos = db_import_repos(cur, repos)
+        assert len(inserted_repos) == 3
+        self._create_testing_system(cur, "s1")
+        inserted = db_import_system_repos(cur, ["repo1", "repo2", "repo3"], "s1")
+        assert len(inserted) == 3
+        deleted_system_repos = db_delete_other_system_repos(cur, ["repo3"], "s1")
+        assert len(deleted_system_repos) == 2


### PR DESCRIPTION
Store data about system's repositories in database tables (repo and system_repo) to enable racalculating based on updated repos only. This will be implemented in the next step.