### PR TITLE
check if kafka lib is installed, skip if not

### DIFF
--- a/wait-for-services.sh
+++ b/wait-for-services.sh
@@ -24,7 +24,7 @@ else
   >&2 echo "Skipping websocket server check"
 fi
 
-if [ ! -z "$KAFKA_HOST" ]; then
+if [ ! -z "$KAFKA_HOST" ] && echo "from kafka import KafkaConsumer" | ./scl-enable.sh /usr/bin/env python3 &> /dev/null; then
   >&2 echo "Checking if Kafka server is up"
   until echo "from kafka import KafkaConsumer;c=KafkaConsumer(bootstrap_servers=[\"$KAFKA_HOST:$KAFKA_PORT\"]);c.close()" | ./scl-enable.sh /usr/bin/env python3 &> /dev/null; do
     >&2 echo "Kafka server is unavailable - sleeping"


### PR DESCRIPTION
fixes regression caused by #363 - KAFKA_HOST is now in common env file and is propagated to containers which don't use it - manager => wait-for-services never finishes