### PR TITLE
don't delete from main repo table and use cache for repo IDs

### DIFF
--- a/listener/upload_listener.py
+++ b/listener/upload_listener.py
@@ -7,6 +7,7 @@ import json
 import os
 import signal
 import tempfile
+from typing import Optional
 from distutils.util import strtobool  # pylint: disable=import-error, no-name-in-module
 import flags
 
@@ -55,7 +56,6 @@ ARCHIVE_NO_RPMDB = Counter('ve_listener_upl_no_rpmdb', '# of systems ignored due
 MESSAGE_PARSE_ERROR = Counter('ve_listener_message_parse_error', '# of message parse errors')
 NEW_REPO = Counter('ve_listener_upl_new_repo', '# of new repos inserted')
 NEW_SYSTEM_REPO = Counter('ve_listener_upl_new_system_repo', '# of new system_repo pairs inserted')
-DELETED_REPO = Counter('ve_listener_upl_repo_deleted', '# deleted repos')
 DELETED_SYSTEM_REPO = Counter('ve_listener_upl_system_repo_deleted', '# deleted system_repo pairs')
 INVALID_IDENTITY = Counter('ve_listener_upl_invalid_identity',
                            '# of skipped uploads because of invalid identity')
@@ -65,6 +65,9 @@ MISSING_SMART_MANAGEMENT = Counter('ve_listener_upl_non_smart_management',
 # kafka clients
 LISTENER_QUEUE = mqueue.MQReader([mqueue.UPLOAD_TOPIC, mqueue.EVENTS_TOPIC])
 EVALUATOR_QUEUE = mqueue.MQWriter(mqueue.EVALUATOR_TOPIC)
+
+# caching repo names to id
+REPO_ID_CACHE = {}
 
 
 class ImportStatus(flags.Flags):
@@ -119,7 +122,6 @@ def db_import_system(inventory_id: str, rh_account: str, s3_url: str, vmaas_json
                 db_import_system_repos(cur, repo_list, inventory_id)
 
                 db_delete_other_system_repos(cur, repo_list, inventory_id)
-                db_delete_unused_repos(cur)
 
                 conn.commit()
 
@@ -169,12 +171,10 @@ def db_import_system_repos(cur, repos: list, inventory_id: str):
     """Import items to system_repo table."""
 
     if repos:
-        cur.execute("""select id from repo where name in %s""", (tuple(repos), ))
-        to_insert = [(inventory_id, repo_id) for repo_id, *_ in cur.fetchall()]
-        if to_insert:
-            execute_values(cur, """insert into system_repo (inventory_id, repo_id) values %s
-                                   on conflict (inventory_id, repo_id) do nothing returning repo_id""",
-                           to_insert, page_size=len(to_insert))
+        to_insert = [(inventory_id, REPO_ID_CACHE[repo]) for repo in repos]
+        execute_values(cur, """insert into system_repo (inventory_id, repo_id) values %s
+                               on conflict (inventory_id, repo_id) do nothing returning repo_id""",
+                       to_insert, page_size=len(to_insert))
         repo_ids = [repo_id for repo_id, *_ in cur.fetchall()]
         if repo_ids:
             NEW_SYSTEM_REPO.inc(len(repo_ids))
@@ -186,10 +186,10 @@ def db_delete_other_system_repos(cur, repos: list, inventory_id: str):
     """Delete all system_repo items not including input repos."""
 
     if repos:
+        repos_ids = [REPO_ID_CACHE[repo] for repo in repos]
         cur.execute("""delete from system_repo sr
-                    where sr.inventory_id = %s and sr.repo_id not in
-                    (select repo.id from repo where repo.name in %s)
-                    returning sr.repo_id""", (inventory_id, tuple(repos)))
+                    where sr.inventory_id = %s and sr.repo_id not in %s
+                    returning sr.repo_id""", (inventory_id, tuple(repos_ids)))
     else:
         cur.execute("""delete from system_repo where inventory_id = %s returning repo_id""",
                     (inventory_id, ))
@@ -202,28 +202,19 @@ def db_delete_other_system_repos(cur, repos: list, inventory_id: str):
 def db_import_repos(cur, repos: list):
     """Ensure input repos to be in repo db table."""
 
-    if repos:
-        to_insert = [(repo, ) for repo in repos]
-        execute_values(cur, """insert into repo (name) values %s on conflict (name) do nothing
-                               returning name""", to_insert, page_size=len(to_insert))
-        repo_names = [repo_name for repo_name, *_ in cur.fetchall()]
-        if repo_names:
-            NEW_REPO.inc(len(repo_names))
+    to_insert = sorted({(repo, ) for repo in repos if repo not in REPO_ID_CACHE})
+    if to_insert:
+        repo_names = []
+        # make sure we do an update on conflict to fetch already existing ID imported by someone else concurrently
+        execute_values(cur, """insert into repo (name) values %s on conflict (name) do update set name = EXCLUDED.name
+                               returning id, name, (xmax = 0) AS inserted""", to_insert, page_size=len(to_insert))
+        for repo_id, repo_name, inserted in cur.fetchall():
+            if inserted:
+                NEW_REPO.inc()
+                repo_names.append(repo_name)
+            REPO_ID_CACHE[repo_name] = repo_id
         return repo_names
     return None
-
-
-def db_delete_unused_repos(cur) -> list:
-    """Delete repos not related with any system."""
-
-    cur.execute("""delete from repo
-                   using repo ljr left join system_repo sr on sr.repo_id = ljr.id
-                   where ljr.id = repo.id and sr.inventory_id is null
-                   returning repo.name""")
-    delete_repo_names = [repo_name for repo_name, *_ in cur.fetchall()]
-    if delete_repo_names:
-        DELETED_REPO.inc(len(delete_repo_names))
-    return delete_repo_names
 
 
 def db_delete_system(inventory_id):
@@ -253,6 +244,20 @@ def db_delete_system(inventory_id):
                 LOGGER.exception("Error deleting system: ")
                 conn.rollback()
             return rtrn
+
+
+def db_init_repo_cache():
+    """Populate initial repo cache"""
+    with DatabasePoolConnection() as conn:
+        with conn.cursor() as cur:
+            try:
+                cur.execute("""SELECT id, name FROM repo""")
+                for repo_id, repo_name in cur.fetchall():
+                    REPO_ID_CACHE[repo_name] = repo_id
+            except DatabaseError:
+                DATABASE_ERROR.inc()
+                LOGGER.exception("Error caching repos: ")
+                conn.rollback()
 
 
 def download_archive(url, tmp_file):
@@ -287,9 +292,10 @@ def download_archive(url, tmp_file):
     return success
 
 
-def parse_archive(upload_data):
+def parse_archive(upload_data: dict) -> (Optional[str], list):
     """Parse archive after it's downloaded."""
-    vmaas_request, repo_list = None, None
+    vmaas_request = None
+    repo_list = []
     with tempfile.NamedTemporaryFile(delete=True) as tmp_file:
         if download_archive(upload_data["url"], tmp_file):
             parser = ArchiveParser(tmp_file.name)
@@ -398,6 +404,8 @@ def main():
         future.add_done_callback(on_thread_done)
 
     with DatabasePool(WORKER_THREADS):
+        # prepare repo name to id cache
+        db_init_repo_cache()
         LISTENER_QUEUE.listen(process_message)
 
         # wait until loop is stopped from terminate callback

--- a/tests/listener_tests/test_upload_listener.py
+++ b/tests/listener_tests/test_upload_listener.py
@@ -15,7 +15,7 @@ import pytest
 import listener.upload_listener
 from listener.upload_listener import format_vmaas_request, db_import_system, process_upload, LOGGER, \
     terminate, LISTENER_QUEUE, EVALUATOR_QUEUE, on_thread_done, download_archive, parse_archive, \
-    db_delete_system, process_delete, ImportStatus, db_import_repos, db_import_system_repos, db_delete_unused_repos, \
+    db_delete_system, process_delete, ImportStatus, db_import_repos, db_import_system_repos, db_init_repo_cache, \
     db_delete_other_system_repos
 from common.database_handler import DatabasePool
 from common.mqueue import MQWriter
@@ -164,7 +164,7 @@ class TestUploadListner:
             assert not caplog.records
 
             # same-id, diff-vmaas upload - should send
-            monkeypatch.setattr(listener.upload_listener, 'parse_archive', lambda upld_dta: (diff_json, None))
+            monkeypatch.setattr(listener.upload_listener, 'parse_archive', lambda upld_dta: (diff_json, []))
             caplog.clear()
             with caplog.at_level(logging.INFO):
                 process_upload(upld_data, None)
@@ -234,6 +234,7 @@ class TestUploadListner:
         cur.execute("""delete from system_repo""")
         cur.execute("""delete from repo""")
         cur.execute("""delete from system_platform where inventory_id in %s""", (inventory_ids,))
+        listener.upload_listener.REPO_ID_CACHE = {}
 
     def test_import_repos(self, pg_db_conn):
         """Test import repos to db. Ensure unique repos."""
@@ -254,6 +255,21 @@ class TestUploadListner:
         assert {"repo1", "repo2", "repo3", "repo4"} == {repo_name for repo_name, *_ in rows}
         self._clean_tmp_db_items(cur, ("s1",))
 
+    def test_init_repo_cache(self, pg_db_conn):
+        """Test initializing repo cache."""
+
+        cur = pg_db_conn.cursor()
+        self._clean_tmp_db_items(cur, ("s1",))
+        inserted = db_import_repos(cur, ["repo1", "repo2", "repo1"])
+        assert len(inserted) == 2
+        assert set(inserted) == {"repo1", "repo2"}
+        assert len(listener.upload_listener.REPO_ID_CACHE) == 2
+        listener.upload_listener.REPO_ID_CACHE = {}
+        with DatabasePool(1):
+            db_init_repo_cache()
+        assert len(listener.upload_listener.REPO_ID_CACHE) == 2
+        self._clean_tmp_db_items(cur, ("s1",))
+
     def test_import_system_repos(self, pg_db_conn):
         """Test import system_repo items to db."""
 
@@ -269,20 +285,6 @@ class TestUploadListner:
         assert len(rows) == 2
         assert set(rows) == {("s1", "repo1"), ("s1", "repo2")}
         self._clean_tmp_db_items(cur, ("s1",))
-
-    def test_delete_unused_repos(self, pg_db_conn):
-        """Test delete unused repo items."""
-
-        cur = pg_db_conn.cursor()
-        self._clean_tmp_db_items(cur, ("s1",))
-        repos = ["repo1", "repo2", "repo3", "repo4"]
-        inserted_repos = db_import_repos(cur, repos)
-        assert len(inserted_repos) == 4
-        self._create_testing_system(cur, "s1")
-        inserted = db_import_system_repos(cur, ["repo1", "repo2"], "s1")
-        assert len(inserted) == 2
-        deleted_repos = db_delete_unused_repos(cur)
-        assert set(deleted_repos) == {"repo3", "repo4"}
 
     def test_delete_other_system_repos(self, pg_db_conn):
         """Test delete not actual system_repo items."""


### PR DESCRIPTION
- don't do a delete from `repo` table, the query is slow to be executed after for every processed archive, append values only
- there is only up to 4000 repo label in RHSM, it can be cached in memory
- #380 helps to ignore custom repos which are useless because VMaaS can't evaluate them