### PR TITLE
wait a bit before retrying request

### DIFF
--- a/common/utils.py
+++ b/common/utils.py
@@ -3,6 +3,7 @@ Various utility functions.
 """
 
 import os
+from time import sleep
 
 from prometheus_client import Counter
 import requests
@@ -38,4 +39,5 @@ def vmaas_post_request(endpoint, data_json, session=None):
         except requests.exceptions.RequestException:
             VMAAS_CNX_ERR.inc()
             LOGGER.exception("Error calling VMAAS: ")
+        sleep(0.1)
     return None


### PR DESCRIPTION
If you start vulnerability-engine while vmaas is not running it's waiting for VMaaS websocket, which comes online earlier before webapp which leads to tone of tracebacks like this:
```
vulnerability-engine-vmaas-sync | Websocket server is unavailable - sleeping
vulnerability-engine-vmaas-sync | Checking if Kafka server is up
vulnerability-engine-vmaas-sync | Everything is up - executing command
vulnerability-engine-vmaas-sync | 66610a6b9502 2019-07-18 07:37:41,596:INFO:common.logging:CloudWatch logging disabled
vulnerability-engine-vmaas-sync | 66610a6b9502 2019-07-18 07:37:41,596:INFO:__main__:Starting VMaaS sync service.
vulnerability-engine-vmaas-sync | 66610a6b9502 2019-07-18 07:37:41,602:INFO:__main__:Syncing CVE metadata
vulnerability-engine-vmaas-sync | 66610a6b9502 2019-07-18 07:37:41,605:INFO:__main__:Downloading CVE metadata (page: 1, page_size: 5000)
vulnerability-engine-vmaas-sync | 66610a6b9502 2019-07-18 07:37:41,610:ERROR:common.utils:Error calling VMAAS: 'Traceback (most recent call last):
...
raise ConnectionError(e, request=request)\nrequests.exceptions.ConnectionError: HTTPConnectionPool(host=\'vmaas_webapp\', port=8080): Max retries exceeded with url: /api/v1/cves (Caused by NewConnectionError(\'<urllib3.connection.HTTPConnection object at 0x7fcac52ae3c8>: Failed to establish a new connection: [Errno 111] Connection refused\',))'|
```

The purpose is to give VMaaS webapp a bit more time to change it's state to fully initialized before retrying the request.