### PR TITLE
base test container on Fedora 29

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM fedora:27
+FROM fedora:29
 
 RUN dnf install -y python3 python3-pip git postgresql-server findutils
 


### PR DESCRIPTION
Fedora 27 has PostgreSQL 9.6 while Fedora 29 has PostgreSQL 10 and we're
running PG 10 in production (and the code is written with PG 10) syntax
which was causing some issues in the tests (dbupgrade test mainly)