### PR TITLE
Fix opted out systems returned wrong number of items

### DIFF
--- a/manager/system_handler.py
+++ b/manager/system_handler.py
@@ -16,6 +16,7 @@ class SystemCvesView(ListView):
     """Database select for /systems endpoint"""
 
     def __init__(self, list_args, query_args, filter_args, parsed_args, uri):
+        # pylint: disable=singleton-comparison
         query = (
             SystemVulnerabilities
             .select(CveMetadata.cve.alias('cve_name'),
@@ -33,6 +34,7 @@ class SystemCvesView(ListView):
             .where(SystemVulnerabilities.when_mitigated.is_null(True))
             .where(SystemPlatform.rh_account == query_args['rh_account_number'])
             .where(SystemPlatform.inventory_id == query_args['inventory_id'])
+            .where(SystemPlatform.opt_out == False)  # noqa: E712
         )
         if 'cvss_from' in filter_args and filter_args['cvss_from']:
             query = query.where(CveMetadata.cvss3_score >= filter_args['cvss_from'])
@@ -162,21 +164,20 @@ class GetSystemsCves(GetRequest):
 
         response = {}
         result = []
-        if not system.opt_out:
-            for cve in cves_view:
-                record = {}
-                record['synopsis'] = cve['cve_name']
-                record['public_date'] = cve['public_date'].isoformat() if cve['public_date'] else ''
-                record['impact'] = cve['impact']
-                record['description'] = cve['cve_description']
-                # Store everything we know about CVSS - maybe UI needs to decide what to show
-                record['cvss2_score'] = str(cve['cvss2_score']) if cve['cvss2_score'] is not None else ''
-                record['cvss3_score'] = str(cve['cvss3_score']) if cve['cvss3_score'] is not None else ''
-                # Store status information
-                record['status_id'] = cve['status_id']
-                record['status'] = cve['status_name']
+        for cve in cves_view:
+            record = {}
+            record['synopsis'] = cve['cve_name']
+            record['public_date'] = cve['public_date'].isoformat() if cve['public_date'] else ''
+            record['impact'] = cve['impact']
+            record['description'] = cve['cve_description']
+            # Store everything we know about CVSS - maybe UI needs to decide what to show
+            record['cvss2_score'] = str(cve['cvss2_score']) if cve['cvss2_score'] is not None else ''
+            record['cvss3_score'] = str(cve['cvss3_score']) if cve['cvss3_score'] is not None else ''
+            # Store status information
+            record['status_id'] = cve['status_id']
+            record['status'] = cve['status_name']
 
-                result.append({'type': 'cve', 'id': cve['cve_name'], 'attributes': record})
+            result.append({'type': 'cve', 'id': cve['cve_name'], 'attributes': record})
         response['meta'] = cves_view.get_metadata()
         response['meta']['opt_out'] = system.opt_out
         response['links'] = cves_view.get_pagination_links()


### PR DESCRIPTION
In [PR#393](https://github.com/RedHatInsights/vulnerability-engine/pull/393) was a problem, when system was opted out and requested the list of CVEs, metadata returned wrong number of _total_items_ (should be 0 when opted out).