### PR TITLE
propagate event loop to successfuly send webhooks message

### DIFF
--- a/evaluator/evaluator.py
+++ b/evaluator/evaluator.py
@@ -100,7 +100,7 @@ class QueueEvaluator:
         self._cve_id_map.update(cve_id_map)
         return new_cves
 
-    def _store_new_cves(self, system_id, inventory_id, new_cves, rh_account, cur):
+    def _store_new_cves(self, system_id, inventory_id, new_cves, rh_account, cur, loop=None):
         new_cves_ids = set()
         if not new_cves:
             return new_cves_ids
@@ -144,7 +144,7 @@ class QueueEvaluator:
                     'message': 'Discovered %s new CVEs with cvss score within %s radius for host id: %s' % (
                         cvss_buckets[level], level, inventory_id),
                 }
-                WEBHOOKS_QUEUE.send(msg)
+                WEBHOOKS_QUEUE.send(msg, loop=loop)
         return new_cves_ids
 
     @staticmethod
@@ -229,7 +229,7 @@ class QueueEvaluator:
         return system_cves
 
     @VMAAS_EVAL_TIME.time()
-    def evaluate_vmaas(self, system_platform, cur):
+    def evaluate_vmaas(self, system_platform, cur, loop=None):
         """Evaluates messages received from vmaas"""
         VMAAS_COUNT.inc()
         system_id = system_platform[0]
@@ -260,7 +260,7 @@ class QueueEvaluator:
         for cve in unprocessed_cves:
             mitigated_cves_ids.add(self._cve_id_map[cve])
 
-        new_cves_ids = self._store_new_cves(system_id, inventory_id, new_cves, rh_account, cur)
+        new_cves_ids = self._store_new_cves(system_id, inventory_id, new_cves, rh_account, cur, loop=loop)
         self._update_mitigated_cves(system_id, mitigated_cves_ids, cur)
         self._update_unmitigated_cves(system_id, unmitigated_cves_ids, cur)
         self._update_system(system_id, len(reported_cves), cur)
@@ -272,7 +272,7 @@ class QueueEvaluator:
 
         LOGGER.debug("Finished evaluating vulnerabilities for inventory_id: %s", inventory_id)
 
-    def process_upload_or_re_evaluate(self, msg_dict: dict, **_):
+    def process_upload_or_re_evaluate(self, msg_dict: dict, loop=None):
         """
         Process function to upload new file or re-evaluate system
         """
@@ -287,7 +287,7 @@ class QueueEvaluator:
                 system_platform = cur.fetchone()
                 if system_platform is not None:
                     try:
-                        self.evaluate_vmaas(system_platform, cur)
+                        self.evaluate_vmaas(system_platform, cur, loop=loop)
                         conn.commit()
                     except DatabaseError:
                         LOGGER.exception("Unable to store data: ")

--- a/tests/evaluator_tests/test_evaluator.py
+++ b/tests/evaluator_tests/test_evaluator.py
@@ -11,7 +11,7 @@ import evaluator.evaluator as evaluator_module
 
 class TestMqueueWriter:
     """Pretends to know how to send() kafka msgs"""
-    def send(self, msg):
+    def send(self, msg, loop=None):  # pylint: disable=unused-argument
         """pretend to be kafka message"""
         LOGGER.info(msg)
 


### PR DESCRIPTION
fixing bug caused by #379 


> 2019-07-29 11:50:49,697:ERROR:common.utils:Future <Future at 0x7f414639feb8 state=finished raised RuntimeError> hit exception: 'Traceback (most recent call last):\n  File "/evaluator/common/utils.py", line 49, in on_thread_done\n    future.result()\n  File "/opt/rh/rh-python36/root/usr/lib64/python3.6/concurrent/futures/_base.py", line 425, in result\n    return self.__get_result()\n  File "/opt/rh/rh-python36/root/usr/lib64/python3.6/concurrent/futures/_base.py", line 384, in __get_result\n    raise self._exception\n  File "/opt/rh/rh-python36/root/usr/lib64/python3.6/concurrent/futures/thread.py", line 56, in run\n    result = self.fn(*self.args, **self.kwargs)\n  File "/evaluator/evaluator/evaluator.py", line 290, in process_upload_or_re_evaluate\n    self.evaluate_vmaas(system_platform, cur)\n  File "<decorator-gen-1>", line 2, in evaluate_vmaas\n  File "/opt/rh/rh-python36/root/usr/lib/python3.6/site-packages/prometheus_client/context_managers.py", line 66, in wrapped\n    return func(*args, **kwargs)\n  File "/evaluator/evaluator/evaluator.py", line 263, in evaluate_vmaas\n    new_cves_ids = self._store_new_cves(system_id, inventory_id, new_cves, rh_account, cur)\n  File "/evaluator/evaluator/evaluator.py", line 147, in _store_new_cves\n    WEBHOOKS_QUEUE.send(msg)\n  File "/evaluator/common/mqueue.py", line 116, in send\n    return asyncio.ensure_future(self.send_one(msg), loop=loop)\n  File "/opt/rh/rh-python36/root/usr/lib64/python3.6/asyncio/tasks.py", line 518, in ensure_future\n    loop = events.get_event_loop()\n  File "/opt/rh/rh-python36/root/usr/lib64/python3.6/asyncio/events.py", line 676, in get_event_loop\n    return get_event_loop_policy().get_event_loop()\n  File "/opt/rh/rh-python36/root/usr/lib64/python3.6/asyncio/events.py", line 584, in get_event_loop\n    % threading.current_thread().name)\nRuntimeError: There is no current event loop in thread \'ThreadPoolExecutor-0_0\'.'|
