### PR TITLE
display systems counts for each status

### DIFF
--- a/manager.spec.yaml
+++ b/manager.spec.yaml
@@ -1152,6 +1152,9 @@ components:
                   type: string
                   description: Synopsis of the CVE.
                   example: CVE-2016-0800
+                systems_status_detail:
+                  type: object
+                  description: Counts of systems with given status type.
               required:
                 - business_risk
                 - business_risk_id
@@ -1170,6 +1173,7 @@ components:
                 - status_id
                 - status_text
                 - synopsis
+                - systems_status_detail
           required:
             - id
             - type

--- a/manager/cve_handler.py
+++ b/manager/cve_handler.py
@@ -3,7 +3,7 @@ Module for /cves API endpoint
 """
 
 import connexion
-from peewee import DoesNotExist, IntegrityError
+from peewee import DoesNotExist, IntegrityError, fn
 from psycopg2 import IntegrityError as psycopg2IntegrityError
 
 from common.logging import get_logger
@@ -117,6 +117,25 @@ class GetCves(GetRequest):
             retval['status'] = DEFAULT_STATUS
             retval['status_id'] = 0
             retval['status_text'] = None
+
+        # add counts of systems with all statuses
+        retval['systems_status_detail'] = {}
+        # pylint: disable=singleton-comparison
+        status_detail = (
+            SystemVulnerabilities
+            .select(SystemVulnerabilities.status, fn.Count(SystemVulnerabilities.status).alias('systems'))
+            .join(SystemPlatform, on=(SystemVulnerabilities.system_id == SystemPlatform.id))
+            .join(CveMetadata, on=(SystemVulnerabilities.cve_id == CveMetadata.id))
+            .join(RHAccount, on=(SystemPlatform.rh_account_id == RHAccount.id))
+            .where(CveMetadata.cve == synopsis)
+            .where(RHAccount.name == connexion.context['user'])
+            .where(SystemVulnerabilities.when_mitigated.is_null(True))
+            .where(SystemPlatform.opt_out == False)  # noqa: E712
+            .group_by(SystemVulnerabilities.status)
+            .dicts()
+        )
+        for row in status_detail:
+            retval['systems_status_detail'][row['status']] = row['systems']
         return retval
 
     @classmethod

--- a/tests/manager_tests/schemas.py
+++ b/tests/manager_tests/schemas.py
@@ -112,6 +112,7 @@ _vmaas_cves_data = {
     "status": str,
     "status_id": int,
     "status_text": Or(None, str),
+    "systems_status_detail": dict,
 }
 
 _system_meta = {


### PR DESCRIPTION
adding new field `systems_status_detail` (can be renamed if you have better idea how to name it) when fetching single CVE detail

first iteration, may be changed later

example

```
./scripts/3scale-mock -a 123456 curl -H "Content-Type: application/vnd.api+json" -X GET "http://localhost:8300/api/vulnerability/v1/cves/CVE-2018-18690"
```

```
{
  "data": {
    "attributes": {
      "business_risk": "Not Defined",
      "business_risk_id": 0,
      "business_risk_text": null,
      "cvss2_metrics": null,
      "cvss2_score": null,
      "cvss3_metrics": null,
      "cvss3_score": null,
      "description": "unknown",
      "impact": "NotSet",
      "modified_date": null,
      "public_date": null,
      "redhat_url": null,
      "secondary_url": null,
      "status": "Not Reviewed",
      "status_id": 0,
      "status_text": null,
      "synopsis": "CVE-2018-18690",
      "systems_status_detail": {
        "0": 1,
        "1": 2,
        "2": 1
      }
    },
    "id": "CVE-2018-18690",
    "type": "cve"
  }
}
```