### PR TITLE
Fix return 500 when string is NULL in PATCH operations

### DIFF
--- a/manager/cve_handler.py
+++ b/manager/cve_handler.py
@@ -193,8 +193,11 @@ class PatchCveRisk(PatchRequest):
         if 'business_risk_id' in data:
             values['business_risk_id'] = data['business_risk_id']
         if 'business_risk_text' in data:
-            values['business_risk_text'] = data['business_risk_text'].strip() \
-                                           if data['business_risk_text'].strip() else None
+            try:
+                values['business_risk_text'] = data['business_risk_text'].strip() \
+                                               if data['business_risk_text'].strip() else None
+            except AttributeError:
+                values['business_risk_text'] = None
         if not values:
             return cls.format_exception(
                 'At least one of the "business_risk_id" or "business_risk_text" parameters is required.', 400)
@@ -245,7 +248,11 @@ class PatchCveStatus(PatchRequest):
         if 'status_id' in data:
             values['status_id'] = data['status_id']
         if 'status_text' in data:
-            values['status_text'] = data['status_text'].strip() if data['status_text'].strip() else None
+            try:
+                values['status_text'] = data['status_text'].strip() \
+                                        if data['status_text'].strip() else None
+            except AttributeError:
+                values['status_text'] = None
         if not values:
             return cls.format_exception(
                 'At least one of the "status_id" or "status_text" parameters is required.', 400)

--- a/manager/status_handler.py
+++ b/manager/status_handler.py
@@ -56,7 +56,10 @@ class PatchStatus(PatchRequest):
             status_to_cves_map[data['status_id']] = in_cve_list
         if 'status_text' in data:
             # single status for all CVEs
-            key = data['status_text'].strip() if data['status_text'].strip() else None
+            try:
+                key = data['status_text'].strip() if data['status_text'].strip() else None
+            except AttributeError:
+                key = None
             status_text_to_cves_map[key] = in_cve_list
         # if neither of status_id or status_text is set => inherit from CVE-level
         if not status_to_cves_map and not status_text_to_cves_map:


### PR DESCRIPTION
I have noticed that there are some 500 returned in PATCH operations when the nullable parameters are actually NULL, because of missing attribute in python object.