### PR TITLE
Fix none type traceback in listener

### DIFF
--- a/listener/upload_listener.py
+++ b/listener/upload_listener.py
@@ -124,7 +124,7 @@ def db_import_system(inventory_id: str, rh_account: str, s3_url: str, vmaas_json
                 DATABASE_ERROR.inc()
                 LOGGER.exception("Error importing system: ")
                 conn.rollback()
-            return status
+    return status
 
 
 def db_import_system_platform(cur, inventory_id: str, rh_account: str, s3_url: str, vmaas_json: str):


### PR DESCRIPTION
`
vulnerability-engine-listener | 2fef32284d0b 2019-09-24 14:26:44,813:ERROR:common.utils:Future <Future at 0x7fc8f2e5c198 state=finished raised TypeError> hit exception: 'Traceback (most recent call last):\n  File "/listener/common/utils.py", line 50, in on_thread_done\n    future.result()\n  File "/opt/rh/rh-python36/root/usr/lib64/python3.6/concurrent/futures/_base.py", line 425, in result\n    return self.__get_result()\n  File "/opt/rh/rh-python36/root/usr/lib64/python3.6/concurrent/futures/_base.py", line 384, in __get_result\n    raise self._exception\n  File "/opt/rh/rh-python36/root/usr/lib64/python3.6/concurrent/futures/thread.py", line 56, in run\n    result = self.fn(*self.args, **self.kwargs)\n  File "/listener/listener/upload_listener.py", line 329, in process_upload\n    if ImportStatus.CHANGED in import_status or DISABLE_OPTIMISATION:\nTypeError: argument of type \'NoneType\' is not iterable'|
`