### PR TITLE
Unify error handling between different request handlers, handle database errors

### DIFF
--- a/manager/base.py
+++ b/manager/base.py
@@ -8,9 +8,8 @@ from math import floor
 import os
 from distutils.util import strtobool  # pylint: disable=import-error, no-name-in-module
 
-
 from flask import Response
-from peewee import fn
+from peewee import fn, DataError
 from prometheus_client import Counter
 
 from common.identity import get_identity, is_entitled_smart_management
@@ -229,6 +228,24 @@ class Request:
             raise ApplicationException({'errors': errors}, 400)
         return retval
 
+    @classmethod
+    def handle_errors(cls, fun, **kwargs):
+        """ Execute provided function, while handling all common errors, and returning a formatted response """
+        try:
+            return fun(**kwargs)
+        except ApplicationException as exc:
+            return exc.format_exception()
+        # TODO: Can this disclose any information ? Should we provide generic response message ?
+        except DataError as exc:
+            return cls.format_exception(str(exc), 400)
+        except InvalidArgumentException as exc:
+            return cls.format_exception(str(exc), 400)
+        except ReadOnlyModeException as exc:
+            return cls.format_exception(str(exc), 503)
+        except Exception:  # pylint: disable=broad-except
+            LOGGER.exception('Unhandled exception: ')
+            return cls.format_exception('Internal server error', 500)
+
 
 class GetRequest(Request):
     """general class for processing GET requests"""
@@ -237,15 +254,7 @@ class GetRequest(Request):
     def get(cls, **kwargs):
         """Answer GET request"""
         REQUEST_COUNTS.labels('get', cls._endpoint_name).inc()
-        try:
-            return cls.handle_get(**kwargs)
-        except ApplicationException as exc:
-            return exc.format_exception()
-        except InvalidArgumentException as exc:
-            return cls.format_exception(str(exc), 400)
-        except Exception:  # pylint: disable=broad-except
-            LOGGER.exception('Unhandled exception: ')
-            return cls.format_exception('Internal server error', 500)
+        return cls.handle_errors(cls.handle_get, **kwargs)
 
     @classmethod
     def handle_get(cls, **kwargs):  # pragma: no cover
@@ -253,25 +262,28 @@ class GetRequest(Request):
         raise NotImplementedError
 
 
-class PatchRequest(Request):
+class ReadWriteRequest(Request):
+    """ Base class for request implementations which require database to be opened in write mode"""
+
+    @classmethod
+    def handle_errors(cls, fun, **kwargs):
+        """ Handle common errors, and check whether read_only mode is enabled or disabled"""
+
+        def readonly_fun(**kwargs):
+            cls._check_read_only_mode()
+            return fun(**kwargs)
+
+        return Request.handle_errors(readonly_fun, **kwargs)
+
+
+class PatchRequest(ReadWriteRequest):
     """general class for processing PATCH requests"""
 
     @classmethod
     def patch(cls, **kwargs):
         """Answer PATCH request"""
         REQUEST_COUNTS.labels('patch', cls._endpoint_name).inc()
-        try:
-            cls._check_read_only_mode()
-            return cls.handle_patch(**kwargs)
-        except ApplicationException as exc:
-            return exc.format_exception()
-        except InvalidArgumentException as exc:
-            return cls.format_exception(str(exc), 400)
-        except ReadOnlyModeException as exc:
-            return cls.format_exception(str(exc), 503)
-        except Exception:  # pylint: disable=broad-except
-            LOGGER.exception('Unhandled exception: ')
-            return cls.format_exception('Internal server error', 500)
+        return cls.handle_errors(cls.handle_patch, **kwargs)
 
     @classmethod
     def handle_patch(cls, **kwargs):  # pragma: no cover
@@ -279,25 +291,14 @@ class PatchRequest(Request):
         raise NotImplementedError
 
 
-class PostRequest(Request):
+class PostRequest(ReadWriteRequest):
     """general class for processing POST requests"""
 
     @classmethod
     def post(cls, **kwargs):
         """Answer POST request"""
         REQUEST_COUNTS.labels('post', cls._endpoint_name).inc()
-        try:
-            cls._check_read_only_mode()
-            return cls.handle_post(**kwargs)
-        except ApplicationException as exc:
-            return exc.format_exception()
-        except InvalidArgumentException as exc:
-            return cls.format_exception(str(exc), 400)
-        except ReadOnlyModeException as exc:
-            return cls.format_exception(str(exc), 503)
-        except Exception:  # pylint: disable=broad-except
-            LOGGER.exception('Unhandled exception: ')
-            return cls.format_exception('Internal server error', 500), 500
+        return cls.handle_errors(cls.handle_post, **kwargs)
 
     @classmethod
     def handle_post(cls, **kwargs):  # pragma: no cover
@@ -305,25 +306,14 @@ class PostRequest(Request):
         raise NotImplementedError
 
 
-class PutRequest(Request):
+class PutRequest(ReadWriteRequest):
     """general class for processing PUT requests"""
 
     @classmethod
     def put(cls, **kwargs):
         """Answer PUT request"""
         REQUEST_COUNTS.labels('put', cls._endpoint_name).inc()
-        try:
-            cls._check_read_only_mode()
-            return cls.handle_put(**kwargs)
-        except ApplicationException as exc:
-            return exc.format_exception()
-        except InvalidArgumentException as exc:
-            return cls.format_exception(str(exc), 400)
-        except ReadOnlyModeException as exc:
-            return cls.format_exception(str(exc), 503)
-        except Exception:  # pylint: disable=broad-except
-            LOGGER.exception('Unhandled exception: ')
-            return cls.format_exception('Internal server error', 500)
+        return cls.handle_errors(cls.handle_put, **kwargs)
 
     @classmethod
     def handle_put(cls, **kwargs):  # pragma: no cover
@@ -331,25 +321,14 @@ class PutRequest(Request):
         raise NotImplementedError
 
 
-class DeleteRequest(Request):
+class DeleteRequest(ReadWriteRequest):
     """general class for processing DELETE requests"""
 
     @classmethod
     def delete(cls, **kwargs):
         """Answer DELETE request"""
         REQUEST_COUNTS.labels('delete', cls._endpoint_name).inc()
-        try:
-            cls._check_read_only_mode()
-            return cls.handle_delete(**kwargs)
-        except ApplicationException as exc:
-            return exc.format_exception()
-        except InvalidArgumentException as exc:
-            return cls.format_exception(str(exc), 400)
-        except ReadOnlyModeException as exc:
-            return cls.format_exception(str(exc), 503)
-        except Exception:  # pylint: disable=broad-except
-            LOGGER.exception('Unhandled exception: ')
-            return cls.format_exception('Internal server error', 500)
+        return cls.handle_errors(cls.handle_delete, **kwargs)
 
     @classmethod
     def handle_delete(cls, **kwargs):  # pragma: no cover

--- a/tests/manager_tests/test_manager.py
+++ b/tests/manager_tests/test_manager.py
@@ -73,6 +73,7 @@ class TestManager(FlaskTestCase):
 
     def test_bad_pagination(self):
         self.vfetch('vulnerabilities/cves?limit=-3&offset=6').check_response(400)
+        self.vfetch('vulnerabilities/cves?limit=9223372036854775808&offset=6').check_response(400)
         self.vfetch('vulnerabilities/cves?limit=0&offset=6').check_response(400)
         self.vfetch('vulnerabilities/cves?limit=zzz&offset=6').check_response(400)
         self.vfetch('vulnerabilities/cves?limit=2&offset=666').check_response(400)


### PR DESCRIPTION
Remove duplication of error handling code between different request base classes.
DataError is now handled, and does not fall through to general Exception case. 

To resolve: Do we want to return `str(exc)` for DataError or provide a custom message, since they could possibly disclose information from the database ? 