### PR TITLE
Add dbdocs generator and dockerfiles for it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ env:
   global:
     - PGPORT=5433
 after_success:
+  - bash scripts/db_docs_generator.sh
   - git config --global user.name "vmaas-bot"
   - git config --global user.email "40663028+vmaas-bot@users.noreply.github.com"
   - pip install python-semantic-release

--- a/Dockerfile.dbdocs
+++ b/Dockerfile.dbdocs
@@ -1,0 +1,3 @@
+FROM schemaspy/schemaspy
+
+ADD /scripts/schemaspy.properties .

--- a/docker-compose-dbdocs.yml
+++ b/docker-compose-dbdocs.yml
@@ -1,0 +1,29 @@
+version: '3'
+
+services:
+  vulnerability_database:
+    container_name: vulnerability-database
+    build:
+        context: .
+        dockerfile: ./Dockerfile-database
+    image: vulnerability-engine/database:latest
+    restart: unless-stopped
+    env_file:
+      - ./conf/common.env
+      - ./conf/database.env
+    ports:
+      - 5432:5432
+    
+  schema_spy:
+    container_name: schema-spy
+    privileged: true
+    build:
+      context: .
+      dockerfile: ./Dockerfile.dbdocs
+    depends_on:
+      - vulnerability_database
+    volumes:
+      - ./scripts/output:/output
+    env_file:
+      - ./conf/database.env
+    command: java -jar schemaspy.jar

--- a/scripts/db_docs_generator.sh
+++ b/scripts/db_docs_generator.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+
+GIT_DOCS="db_docs"
+VE_DB_SCHEMA="ve_db_postgresql.sql"
+VE_DB_MASTER="./db_docs/ve_database_master"
+VE_DB_STABLE="./db_docs/ve_database_stable"
+ORIGINAL_CSUM="dbscript_csum"
+DB_DOCS_OUTPUT="output"
+TEMP_CSUM="new_csum"
+
+if [[ "$TRAVIS_BRANCH" != "master" ]] && [[ "$TRAVIS_BRANCH" != "stable" ]] || [[ "$TRAVIS_PULL_REQUEST" != "false" ]]
+then
+    echo "Database schema is updated only on pushes into master/stable."
+    exit 0
+fi
+
+if [[ "$VULNERABILITY_DOCS_TOKEN" == "" ]]
+then 
+    echo "Cannot find github token for pushing into docs repo."
+    exit 1
+fi
+
+echo "Current branch of vmaas: ${TRAVIS_BRANCH}"
+
+echo "Calculating checksum for ${VE_DB_SCHEMA}"
+cd scripts
+git clone https://github.com/RedHatInsights/vulnerability-docs.git $GIT_DOCS 
+sha1sum ../database/schema/$VE_DB_SCHEMA > $TEMP_CSUM 
+DIFF_RESULT=0
+
+if [[ "$TRAVIS_BRANCH" == "stable" ]]
+then
+    diff $TEMP_CSUM $VE_DB_STABLE/$ORIGINAL_CSUM > /dev/null
+    DIFF_RESULT=$?
+else
+    diff $TEMP_CSUM $VE_DB_MASTER/$ORIGINAL_CSUM > /dev/null
+    DIFF_RESULT=$?
+fi
+
+if [[ "$DIFF_RESULT" == "1" ]]
+then
+    echo "Commit has new changes in schema, regenerating docs"
+    echo "Creating output directory for docs"
+    mkdir $DB_DOCS_OUTPUT 
+    sudo chmod -R 777 $DB_DOCS_OUTPUT
+
+    echo "Starting schemaspy container and creating docs"
+    cd ..
+    sudo systemctl stop postgresql.service
+    docker-compose -f docker-compose-dbdocs.yml up --build schema_spy
+
+    echo "Stopping containers"
+    docker container stop vulnerability-engine-database
+    sudo systemctl start postgresql.service
+
+    echo "Moving the schema image"
+    cd scripts
+    sudo chmod -R 777 $DB_DOCS_OUTPUT
+    if [[ "$TRAVIS_BRANCH" == "stable" ]]
+    then
+        COMMIT_MESSAGE="Updating VE stable docs for commit $(git rev-parse --short HEAD)"
+        rm -rf $VE_DB_STABLE/*
+        mv ./$DB_DOCS_OUTPUT/* $VE_DB_STABLE
+        mv -f $TEMP_CSUM $VE_DB_STABLE/$ORIGINAL_CSUM
+    else
+        COMMIT_MESSAGE="Updating VE master docs for commit $(git rev-parse --short HEAD)"
+        rm -rf $VE_DB_MASTER/*
+        mv ./$DB_DOCS_OUTPUT/* $VE_DB_MASTER
+        mv -f $TEMP_CSUM $VE_DB_MASTER/$ORIGINAL_CSUM 
+    fi
+
+    git config --global user.name "vmaas-bot"
+    git config --global user.email "40663028+vmaas-bot@users.noreply.github.com"
+
+    GIT_LOCATION="https://vmaas-bot:${VULNERABILITY_DOCS_TOKEN}@github.com/RedHatInsights/vulnerability-docs.git"
+
+    cd $GIT_DOCS
+    git add .
+    git commit -m "$COMMIT_MESSAGE"
+    git push "$GIT_LOCATION"
+    
+    cd ..
+    rm -rf $DB_DOCS_OUTPUT
+else
+    echo "Schema is unchanged, done."
+    rm $TEMP_CSUM
+fi
+
+rm -rf $GIT_DOCS

--- a/scripts/schemaspy.properties
+++ b/scripts/schemaspy.properties
@@ -1,0 +1,8 @@
+# type of database. Run with -dbhelp for details
+schemaspy.t=pgsql
+# database properties: host, port number, name user, password
+schemaspy.host=ve_database
+schemaspy.port=5432
+schemaspy.db=vulnerability
+schemaspy.u=ve_db_admin
+schemaspy.p=ve_db_admin_pwd


### PR DESCRIPTION
The same for vulnerability engine from [vmaas](https://github.com/RedHatInsights/vmaas/pull/612).

Only difference in the scripts are the ve folders paths and that the postgres service in travis must be stopped because the 5432 port is taken by postgresql.service, the service is started up after generation.