### PR TITLE
fix(listener): avoid comparing similar timestamps from different cont…

### DIFF
--- a/listener/upload_listener.py
+++ b/listener/upload_listener.py
@@ -154,10 +154,10 @@ def db_import_system_platform(cur, inventory_id: str, rh_account: str, s3_url: s
                 VALUES (%s, %s, %s, %s, %s, CURRENT_TIMESTAMP)
                 ON CONFLICT (inventory_id) DO UPDATE SET
                 rh_account_id = %s, s3_url = %s, vmaas_json = %s, json_checksum = %s, last_upload = CURRENT_TIMESTAMP
-                RETURNING (xmax = 0) AS inserted, unchanged_since, id""",
+                RETURNING (xmax = 0) AS inserted, unchanged_since, last_evaluation, id""",
                 (inventory_id, rh_account_id, s3_url, vmaas_json, json_checksum,
                  rh_account_id, s3_url, vmaas_json, json_checksum))
-    inserted, unchanged_since, system_id = cur.fetchone()
+    inserted, unchanged_since, last_evaluation, system_id = cur.fetchone()
     if inserted:
         import_status = ImportStatus.INSERTED
         NEW_SYSTEM.inc()
@@ -165,7 +165,7 @@ def db_import_system_platform(cur, inventory_id: str, rh_account: str, s3_url: s
         import_status = ImportStatus.UPDATED
         UPDATE_SYSTEM.inc()
 
-    if inserted or (unchanged_since > curr_time):
+    if inserted or not last_evaluation or (unchanged_since > last_evaluation):
         import_status |= ImportStatus.CHANGED
     return import_status, system_id
 

--- a/tests/listener_tests/test_upload_listener.py
+++ b/tests/listener_tests/test_upload_listener.py
@@ -17,7 +17,7 @@ from listener.upload_listener import format_vmaas_request, db_import_system, pro
     terminate, LISTENER_QUEUE, EVALUATOR_QUEUE, on_thread_done, download_archive, parse_archive, \
     db_delete_system, process_delete, ImportStatus, db_import_repos, db_import_system_repos, db_init_repo_cache, \
     db_delete_other_system_repos
-from common.database_handler import DatabasePool
+from common.database_handler import DatabasePool, DatabasePoolConnection
 from common.mqueue import MQWriter
 
 # We should refactor upload_listener to be a class where db and other things
@@ -112,6 +112,14 @@ class TestUploadListner:
                                                  % download_server_host})
         assert vmaas_request is None
 
+    @staticmethod
+    def _mark_evaluated(inventory_id: str):
+        with DatabasePoolConnection() as conn:
+            with conn.cursor() as cur:
+                cur.execute("""update system_platform set last_evaluation = CURRENT_TIMESTAMP
+                               where inventory_id = %s""", (inventory_id,))
+            conn.commit()
+
     def test_import_system(self, pg_db_conn, caplog):  # pylint: disable=unused-argument
         """Test importing a system not-in-the-db, followed by same so it's-already-there"""
         # new system
@@ -119,6 +127,8 @@ class TestUploadListner:
             rtrn = db_import_system(A_SYSTEM['inv-id'], A_SYSTEM['rh-acct'], A_SYSTEM['s3-url'],
                                     A_SYSTEM['vmaas-json'], [])
             assert ImportStatus.INSERTED | ImportStatus.CHANGED == rtrn
+
+            self._mark_evaluated(A_SYSTEM['inv-id'])
 
             # And now it's an rtrn['updated'], but same json
             rtrn = db_import_system(A_SYSTEM['inv-id'], A_SYSTEM['rh-acct'], A_SYSTEM['s3-url'],
@@ -156,6 +166,8 @@ class TestUploadListner:
             with caplog.at_level(logging.INFO):
                 process_upload(upld_data, None)
             assert caplog.records[0].msg == 'SENT'
+
+            self._mark_evaluated(upld_data['id'])
 
             # re-upload - should not send
             caplog.clear()


### PR DESCRIPTION
…ainers/machines

clocks may be slightly out of sync

better compare with last evaluation timestamp to decide if re-evaluate again

should fix unreliable re-evaluation when archive changes