### PR TITLE
chore: add debugging service

### DIFF
--- a/scripts/openshift-debugger/Dockerfile
+++ b/scripts/openshift-debugger/Dockerfile
@@ -1,0 +1,24 @@
+FROM registry.access.redhat.com/ubi8/ubi-minimal
+
+ARG PG_REPO=https://download.postgresql.org/pub/repos/yum/10/redhat/rhel-8-x86_64/
+ARG PG_RPM=postgresql10-10.9-1PGDG.rhel8.x86_64.rpm
+ARG PG_LIBS_RPM=postgresql10-libs-10.9-1PGDG.rhel8.x86_64.rpm
+RUN microdnf install python3 which shadow-utils diffutils systemd libicu tar rsync vim && microdnf clean all && \
+    curl -o /tmp/${PG_RPM} ${PG_REPO}${PG_RPM} && \
+    curl -o /tmp/${PG_LIBS_RPM} ${PG_REPO}${PG_LIBS_RPM} && \
+    rpm -ivh /tmp/${PG_RPM} /tmp/${PG_LIBS_RPM} && \
+    rm /tmp/${PG_RPM} /tmp/${PG_LIBS_RPM}
+
+WORKDIR /debugger
+ADD /tests/Pipfile*                      /debugger/
+
+ENV LC_ALL=C.utf8
+ENV LANG=C.utf8
+RUN pip3 install --upgrade pipenv && \
+    pipenv install --system && pipenv check
+
+RUN adduser --gid 0 -d /debugger --no-create-home insights
+RUN chown -R insights:0 /debugger && chmod 777 /debugger
+USER insights
+
+CMD ["sleep", "infinity"]

--- a/scripts/openshift-debugger/debugger.yml
+++ b/scripts/openshift-debugger/debugger.yml
@@ -1,0 +1,138 @@
+{
+    "kind": "List",
+    "apiVersion": "v1",
+    "metadata": {},
+    "items": [
+        {
+            "apiVersion": "build.openshift.io/v1",
+            "kind": "BuildConfig",
+            "metadata": {
+                "labels": {
+                    "app": "vulnerability-engine-debugger"
+                },
+                "name": "vulnerability-engine-debugger"
+            },
+            "spec": {
+                "output": {
+                    "to": {
+                        "kind": "ImageStreamTag",
+                        "name": "vulnerability-engine-debugger:latest"
+                    }
+                },
+                "resources": {
+                    "limits": {
+                        "cpu": "500m",
+                        "memory": "512Mi"
+                    }
+                },
+                "source": {
+                    "git": {
+                        "ref": "master",
+                        "uri": "https://github.com/RedHatInsights/vulnerability-engine.git"
+                    },
+                    "type": "Git"
+                },
+                "strategy": {
+                    "dockerStrategy": {
+                        "dockerfilePath": "scripts/openshift-debugger/Dockerfile",
+                        "forcePull": true
+                    },
+                    "type": "Docker"
+                }
+            }
+        },
+        {
+            "apiVersion": "image.openshift.io/v1",
+            "kind": "ImageStream",
+            "metadata": {
+                "labels": {
+                    "app": "vulnerability-engine-debugger"
+                },
+                "name": "vulnerability-engine-debugger",
+                "spec": {
+                    "dockerImageRepository": "",
+                    "tags": [
+                        {
+                            "name": "latest"
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "apiVersion": "apps.openshift.io/v1",
+            "kind": "DeploymentConfig",
+            "metadata": {
+                "labels": {
+                    "app": "vulnerability-engine-debugger"
+                },
+                "name": "vulnerability-engine-debugger"
+            },
+            "spec": {
+                "replicas": 0,
+                "selector": {
+                    "app": "vulnerability-engine-debugger",
+                    "deploymentconfig": "vulnerability-engine-debugger"
+                },
+                "strategy": {
+                    "resources": {},
+                    "type": "Recreate"
+                },
+                "template": {
+                    "metadata": {
+                        "labels": {
+                            "app": "vulnerability-engine-debugger",
+                            "deploymentconfig": "vulnerability-engine-debugger"
+                        },
+                        "name": "vulnerability-engine-debugger"
+                    },
+                    "spec": {
+                        "containers": [
+                            {
+                                "image": "buildfactory/vulnerability-engine-debugger:latest",
+                                "imagePullPolicy": "Always",
+                                "name": "vulnerability-engine-debugger",
+                                "resources": {
+                                    "limits": {
+                                        "cpu": "200m",
+                                        "memory": "512Mi"
+                                    },
+                                    "requests": {
+                                        "cpu": "200m",
+                                        "memory": "512Mi"
+                                    }
+                                },
+                                "terminationMessagePath": "/dev/termination-log",
+                                "terminationMessagePolicy": "File"
+                            }
+                        ],
+                        "dnsPolicy": "ClusterFirst",
+                        "restartPolicy": "Always",
+                        "schedulerName": "default-scheduler",
+                        "securityContext": {},
+                        "terminationGracePeriodSeconds": 30
+                    }
+                },
+                "test": false,
+                "triggers": [
+                    {
+                        "type": "ConfigChange"
+                    },
+                    {
+                        "imageChangeParams": {
+                            "automatic": true,
+                            "containerNames": [
+                                "vulnerability-engine-debugger"
+                            ],
+                            "from": {
+                                "kind": "ImageStreamTag",
+                                "name": "vulnerability-engine-debugger:latest"
+                            }
+                        },
+                        "type": "ImageChange"
+                    }
+                ]
+            }
+        }
+    ]
+}


### PR DESCRIPTION
other containers don't have psql, tar etc. and it's difficult to do any debugging from them

this container could be deployed in a project to do some basic debugging (not deployed automatically)