### PR TITLE
Fix: metrics dockerfile failing due to missing .txt files

### DIFF
--- a/metrics/Dockerfile
+++ b/metrics/Dockerfile
@@ -16,7 +16,6 @@ RUN adduser --gid 0 -d /metrics --no-create-home insights
 USER insights
 
 ADD /common/*.py             /metrics/common/
-ADD /metrics/*.txt           /metrics/
 ADD /metrics/*.py            /metrics/metrics/
 
 CMD python3 -m metrics.metrics_gather


### PR DESCRIPTION
Docker builds are failing due to .txt files no longer existing in the 'metrics' dir
