### PR TITLE
fix: fix error when bucket is empty

### DIFF
--- a/metrics/s3_bucket_manager.py
+++ b/metrics/s3_bucket_manager.py
@@ -27,8 +27,9 @@ class S3BucketManager():
         """Get the list of keys for data in the bucket."""
         key_list = []
         response = self.s3_client.list_objects_v2(Bucket=S3_BUCKET)
-        for content in response['Contents']:
-            key_list.append(content['Key'])
+        if 'Contents' in response:
+            for content in response['Contents']:
+                key_list.append(content['Key'])
         if self.debug:
             print("Keys in bucket %s: %s" % (S3_BUCKET, key_list))
         return key_list


### PR DESCRIPTION
QE found an issue when metrics runs against an empty S3 bucket.  This only happens the first time metrics is run in an environment, after that the bucket will always contain something.  This fixes the error.