### PR TITLE
fix(dbdocs): fix generating bug for db docs

### DIFF
--- a/docker-compose-dbdocs.yml
+++ b/docker-compose-dbdocs.yml
@@ -5,7 +5,7 @@ services:
     container_name: vulnerability-database
     build:
         context: .
-        dockerfile: ./Dockerfile-database
+        dockerfile: ./database/Dockerfile
     image: vulnerability-engine/database:latest
     restart: unless-stopped
     env_file:

--- a/scripts/db_docs_generator.sh
+++ b/scripts/db_docs_generator.sh
@@ -78,7 +78,7 @@ then
     git add .
     git commit -m "$COMMIT_MESSAGE"
     git push "$GIT_LOCATION"
-    
+
     cd ..
     rm -rf $DB_DOCS_OUTPUT
 else


### PR DESCRIPTION
There was wrong database dockerfile choosed, since the refactorization of engine. So it could not generate a documentation for db.