### PR TITLE
chore: Revert "disable pipenv check because pyup.io is down"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ notifications:
 install:
   - pip install -U pip pipenv codecov
   - cd tests
-  - pipenv install --ignore-pipfile --deploy --system #&& pipenv check --system
+  - pipenv install --ignore-pipfile --deploy --system && pipenv check --system
   - cd ..
 script:
   - PIPENV_VERBOSITY=-1 /bin/bash run_tests.sh

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -18,7 +18,7 @@ WORKDIR /engine
 
 ENV LC_ALL=en_US.utf8
 ENV LANG=en_US.utf8
-RUN pipenv install --ignore-pipfile --deploy && ln -s /usr/bin/python3 /usr/bin/python #&& pipenv check --system
+RUN pipenv install --ignore-pipfile --deploy && ln -s /usr/bin/python3 /usr/bin/python && pipenv check --system
 
 ADD . /engine
 

--- a/advisor_listener/Dockerfile
+++ b/advisor_listener/Dockerfile
@@ -13,7 +13,7 @@ ADD /advisor_listener/Pipfile*        /advisor_listener/
 ENV LC_ALL=C.utf8
 ENV LANG=C.utf8
 RUN pip3 install --upgrade pipenv && \
-    pipenv install --ignore-pipfile --deploy --system && ln -s /usr/bin/python3 /usr/bin/python #&& pipenv check --system
+    pipenv install --ignore-pipfile --deploy --system && ln -s /usr/bin/python3 /usr/bin/python && pipenv check --system
 
 RUN /generate_rpm_list.sh > /tmp/final_rpm_list.txt
 ENV MANIFEST_PREFIX="mgmt_services:VERSION:vulnerability-engine-advisor_listener\/"

--- a/evaluator/Dockerfile
+++ b/evaluator/Dockerfile
@@ -13,7 +13,7 @@ ADD /evaluator/Pipfile*        /evaluator/
 ENV LC_ALL=C.utf8
 ENV LANG=C.utf8
 RUN pip3 install --upgrade pipenv && \
-    pipenv install --ignore-pipfile --deploy --system && ln -s /usr/bin/python3 /usr/bin/python #&& pipenv check --system
+    pipenv install --ignore-pipfile --deploy --system && ln -s /usr/bin/python3 /usr/bin/python && pipenv check --system
 
 RUN /generate_rpm_list.sh > /tmp/final_rpm_list.txt
 ENV MANIFEST_PREFIX="mgmt_services:VERSION:vulnerability-engine-evaluator\/"

--- a/listener/Dockerfile
+++ b/listener/Dockerfile
@@ -13,7 +13,7 @@ ADD /listener/Pipfile*        /listener/
 ENV LC_ALL=C.utf8
 ENV LANG=C.utf8
 RUN pip3 install --upgrade pipenv && \
-    pipenv install --ignore-pipfile --deploy --system && ln -s /usr/bin/python3 /usr/bin/python #&& pipenv check --system
+    pipenv install --ignore-pipfile --deploy --system && ln -s /usr/bin/python3 /usr/bin/python && pipenv check --system
 
 RUN /generate_rpm_list.sh > /tmp/final_rpm_list.txt
 ENV MANIFEST_PREFIX="mgmt_services:VERSION:vulnerability-engine-listener\/"

--- a/manager/Dockerfile
+++ b/manager/Dockerfile
@@ -26,7 +26,7 @@ ADD /manager/Pipfile*                      /manager/
 ENV LC_ALL=C.utf8
 ENV LANG=C.utf8
 RUN pip3 install --upgrade pipenv && \
-    pipenv install --ignore-pipfile --deploy --system && ln -s /usr/bin/python3 /usr/bin/python #&& pipenv check --system
+    pipenv install --ignore-pipfile --deploy --system && ln -s /usr/bin/python3 /usr/bin/python && pipenv check --system
 
 RUN /generate_rpm_list.sh > /tmp/final_rpm_list.txt
 ENV MANIFEST_PREFIX="mgmt_services:VERSION:vulnerability-engine-manager\/"

--- a/metrics/Dockerfile
+++ b/metrics/Dockerfile
@@ -9,7 +9,7 @@ ADD /metrics/Pipfile*    /metrics/
 ENV LC_ALL=C.utf8
 ENV LANG=C.utf8
 RUN pip3 install --upgrade pipenv && \
-    pipenv install --ignore-pipfile --deploy --system && ln -s /usr/bin/python3 /usr/bin/python #&& pipenv check --system
+    pipenv install --ignore-pipfile --deploy --system && ln -s /usr/bin/python3 /usr/bin/python && pipenv check --system
 
 RUN adduser --gid 0 -d /metrics --no-create-home insights
 

--- a/platform_mock/Dockerfile
+++ b/platform_mock/Dockerfile
@@ -9,7 +9,7 @@ ADD /platform_mock/Pipfile*        /platform_mock/
 ENV LC_ALL=C.utf8
 ENV LANG=C.utf8
 RUN pip3 install --upgrade pipenv && \
-    pipenv install --ignore-pipfile --deploy --system && ln -s /usr/bin/python3 /usr/bin/python #&& pipenv check --system
+    pipenv install --ignore-pipfile --deploy --system && ln -s /usr/bin/python3 /usr/bin/python && pipenv check --system
 
 RUN cd /platform_mock && \
     mkdir kafka && \

--- a/scripts/openshift-debugger/Dockerfile
+++ b/scripts/openshift-debugger/Dockerfile
@@ -21,7 +21,7 @@ ADD /scripts/inventory_sync.py           /debugger/
 ENV LC_ALL=C.utf8
 ENV LANG=C.utf8
 RUN pip3 install --upgrade pipenv && \
-    pipenv install --ignore-pipfile --deploy --system && ln -s /usr/bin/python3 /usr/bin/python #&& pipenv check --system
+    pipenv install --ignore-pipfile --deploy --system && ln -s /usr/bin/python3 /usr/bin/python && pipenv check --system
 
 RUN adduser --gid 0 -d /debugger --no-create-home insights
 RUN chown -R insights:0 /debugger && chmod 777 /debugger

--- a/taskomatic/Dockerfile
+++ b/taskomatic/Dockerfile
@@ -13,7 +13,7 @@ ADD /taskomatic/Pipfile* /taskomatic/
 ENV LC_ALL=C.utf8
 ENV LANG=C.utf8
 RUN pip3 install --upgrade pipenv && \
-    pipenv install --ignore-pipfile --deploy --system && ln -s /usr/bin/python3 /usr/bin/python #&& pipenv check --system
+    pipenv install --ignore-pipfile --deploy --system && ln -s /usr/bin/python3 /usr/bin/python && pipenv check --system
 
 RUN /generate_rpm_list.sh > /tmp/final_rpm_list.txt
 ENV MANIFEST_PREFIX="mgmt_services:VERSION:vulnerability-engine-taskomatic\/"

--- a/vmaas_sync/Dockerfile
+++ b/vmaas_sync/Dockerfile
@@ -13,7 +13,7 @@ ADD /vmaas_sync/Pipfile*        /vmaas_sync/
 ENV LC_ALL=C.utf8
 ENV LANG=C.utf8
 RUN pip3 install --upgrade pipenv && \
-    pipenv install --ignore-pipfile --deploy --system && ln -s /usr/bin/python3 /usr/bin/python #&& pipenv check --system
+    pipenv install --ignore-pipfile --deploy --system && ln -s /usr/bin/python3 /usr/bin/python && pipenv check --system
 
 RUN /generate_rpm_list.sh > /tmp/final_rpm_list.txt
 ENV MANIFEST_PREFIX="mgmt_services:VERSION:vulnerability-engine-vmaas-sync\/"


### PR DESCRIPTION
This reverts commit be12c55b310edf2c97104a2ecaa315c86dfa6386.