### PR TITLE
fix(advisor_listener): don't cause VMaaS hits with inactive rules

### DIFF
--- a/advisor_listener/advisor_listener.py
+++ b/advisor_listener/advisor_listener.py
@@ -278,8 +278,8 @@ def db_init_caches():
 
 def insert_new_cves(cur, system_id, new_rule_hits):
     """Import completely new system_vulnerability record, not found by VMaaS"""
-    cve_system_list = [(system_id, cve, new_rule_hits[cve]['id'], new_rule_hits[cve]['details'],) for cve in new_rule_hits]
-    execute_values(cur, """INSERT INTO system_vulnerabilities (system_id, cve_id, rule_id, rule_hit_details) values %s""",
+    cve_system_list = [(system_id, cve, new_rule_hits[cve]['id'], new_rule_hits[cve]['details'], 'now()',) for cve in new_rule_hits]
+    execute_values(cur, """INSERT INTO system_vulnerabilities (system_id, cve_id, rule_id, rule_hit_details, when_mitigated) values %s""",
                    cve_system_list, page_size=len(cve_system_list))
 
 


### PR DESCRIPTION
When creating new record in system_vulnerabililies insert into
when_mitigated to make sure evaluator corretly handles situation where
new CVE appears first in advisor listener and then in evaluator.
With inactive rules evaluator and when_mitigated set to NULL evaluator
thinks that this CVE has been previously processed by it and does not
update CVE count caches accordingly.
Additionally for inactive rules and cases where VMaaS says that the CVE
is not applicable it creates short period of false positivity untill
when_mitigated is set by evaluator.