### PR TITLE
Update payload_id to request_id

### DIFF
--- a/common/utils.py
+++ b/common/utils.py
@@ -75,13 +75,13 @@ def format_datetime(datetime_obj):
 
 def send_msg_to_payload_tracker(producer, msg_dict, status, status_msg=None, loop=None):
     """prepare and send message to payload-tracker"""
-    payload_id = msg_dict['platform_metadata'].get('request_id')
-    if not payload_id:
+    request_id = msg_dict['platform_metadata'].get('request_id')
+    if not request_id:
         return
     tracking_payload = {
         'service': 'vulnerability',
         'account': msg_dict['host']['account'],
-        'payload_id': payload_id,
+        'request_id': request_id,
         'inventory_id': msg_dict["host"]["id"],
         'status': status,
         'date': str(datetime.utcnow())}


### PR DESCRIPTION
The Payload Tracker is transitioning to using the new "request_id" terminology instead of the legacy "payload_id." This renames that field.