### PR TITLE
fix concurrent system import/delete

### DIFF
--- a/advisor_listener/advisor_listener.py
+++ b/advisor_listener/advisor_listener.py
@@ -1,13 +1,11 @@
 """Rules engine results listener"""
 import asyncio
-from datetime import datetime, timedelta
 import json
 from os import getenv
 import signal
 
 from prometheus_client import Counter, start_http_server
 from psycopg2.extras import execute_values
-import pytz
 
 from common import mqueue
 from common.bounded_executor import BoundedExecutor
@@ -217,6 +215,7 @@ def db_import_system(system_data: dict, rule_hits: dict):
         with conn.cursor() as cur:
             rh_account_id, system_id, opt_out, stale = db_import_system_platform(cur, system_data)
             if system_id is None:
+                conn.rollback()
                 return
             db_import_rule_hits(cur, rh_account_id, system_id, opt_out, stale, rule_hits)
             conn.commit()
@@ -224,14 +223,6 @@ def db_import_system(system_data: dict, rule_hits: dict):
 
 def db_import_system_platform(cur, system_data: dict):
     """Import/update system platform data"""
-    curr_time = datetime.now(tz=pytz.utc)
-    cur.execute("""select inventory_id from deleted_systems where inventory_id = %s and when_deleted > %s""",
-                (system_data['inventory_id'], curr_time - timedelta(hours=SYSTEM_DELETION_THRESHOLD, )))
-    if cur.fetchone() is not None:
-        LOGGER.warning('Received recently deleted inventory id: %s', system_data['inventory_id'])
-        DELETED_UPLOADED.inc()
-        return None, None, None, None
-
     cur.execute("""INSERT INTO rh_account (name) VALUES(%s) ON CONFLICT (name) DO NOTHING
                 RETURNING (xmax = 0) AS inserted""", (system_data['rh_account'],))
     inserted = cur.fetchone()
@@ -246,11 +237,15 @@ def db_import_system_platform(cur, system_data: dict):
                 VALUES (%s, %s, %s, now())
                 ON CONFLICT (inventory_id) DO UPDATE SET
                 rh_account_id = %s, display_name = %s, advisor_evaluated = now()
-                RETURNING (xmax = 0) AS inserted, id, opt_out, stale""",
+                RETURNING (xmax = 0) AS inserted, id, opt_out, stale, when_deleted""",
                 (system_data['inventory_id'], rh_account_id, system_data['display_name'],
                  rh_account_id, system_data['display_name']))
 
-    inserted, system_id, opt_out, stale = cur.fetchone()
+    inserted, system_id, opt_out, stale, when_deleted = cur.fetchone()
+    if when_deleted:
+        LOGGER.warning('Received recently deleted inventory id: %s', system_data['inventory_id'])
+        DELETED_UPLOADED.inc()
+        return None, None, None, None
     if inserted:
         NEW_SYSTEM.inc()
     else:

--- a/common/peewee_model.py
+++ b/common/peewee_model.py
@@ -48,6 +48,7 @@ class SystemPlatform(BaseModel):
     stale_warning_timestamp = DateTimeField(null=True)
     culled_timestamp = DateTimeField(null=True)
     stale = BooleanField(null=False)
+    when_deleted = DateTimeField(null=True)
 
     class Meta:
         """system_platform table metadata"""

--- a/conf/listener.env
+++ b/conf/listener.env
@@ -5,4 +5,3 @@ UPLOAD_TOPIC=platform.inventory.host-egress
 EVENTS_TOPIC=platform.inventory.events
 PROMETHEUS_PORT=8086
 DISABLE_OPTIMISATION=False
-SYSTEM_DELETION_THRESHOLD=24

--- a/conf/taskomatic.env
+++ b/conf/taskomatic.env
@@ -1,4 +1,5 @@
 POSTGRESQL_USER=ve_db_user_taskomatic
 POSTGRESQL_PASSWORD=ve_db_user_taskomatic_pwd
-JOBS=stale_systems:5,rules_details:60
+JOBS=stale_systems:5,rules_details:60,delete_systems:360
 INSIGHTS_RULES_API=http://platform_mock:8000/api/insights/v1/rule/
+SYSTEM_DELETION_THRESHOLD=24

--- a/database/schema/upgrade_scripts/059-deleted_table_removal.sql
+++ b/database/schema/upgrade_scripts/059-deleted_table_removal.sql
@@ -1,0 +1,186 @@
+ALTER TABLE system_platform ADD when_deleted TIMESTAMP WITH TIME ZONE;
+
+CREATE INDEX ON system_platform(when_deleted);
+
+DROP TABLE deleted_systems;
+
+CREATE OR REPLACE FUNCTION refresh_all_cached_counts()
+  RETURNS void AS
+$refresh_all_cached_counts$
+  BEGIN
+    -- update cve count for ordered systems
+    WITH to_update_systems AS (
+      SELECT sp.id
+      FROM system_platform sp
+      ORDER BY sp.rh_account_id, sp.id
+      FOR UPDATE OF sp
+    )
+    UPDATE system_platform sp SET cve_count_cache = (
+      SELECT COUNT(cve_id) FROM system_vulnerabilities sv LEFT OUTER JOIN
+                                insights_rule ir ON sv.rule_id = ir.id
+      WHERE sv.system_id = sp.id AND (sv.when_mitigated IS NULL OR ir.active = 'T')
+    )
+    FROM to_update_systems
+    WHERE sp.id = to_update_systems.id;
+
+    -- update system count for ordered cves
+    WITH locked_rows AS (
+      SELECT cad.rh_account_id, cad.cve_id
+      FROM cve_account_data cad
+      ORDER BY cad.rh_account_id, cad.cve_id
+      FOR UPDATE OF cad
+    ), current_counts AS (
+      SELECT sv.cve_id, sp.rh_account_id, count(sv.system_id) as systems_affected
+      FROM system_vulnerabilities sv INNER JOIN
+           system_platform sp ON sv.system_id = sp.id LEFT OUTER JOIN
+           insights_rule ir ON sv.rule_id = ir.id
+      WHERE sp.when_deleted IS NULL AND
+            (sp.last_evaluation IS NOT NULL OR sp.advisor_evaluated IS NOT NULL) AND
+            (sp.opt_out = FALSE AND sp.stale = FALSE) AND
+            (sv.when_mitigated IS NULL OR
+            ir.active = 'T')
+      GROUP BY sv.cve_id, sp.rh_account_id
+    ), upserted AS (
+      INSERT INTO cve_account_data (cve_id, rh_account_id, systems_affected)
+        SELECT cve_id, rh_account_id, systems_affected FROM current_counts
+      ON CONFLICT (cve_id, rh_account_id) DO UPDATE SET
+        systems_affected = EXCLUDED.systems_affected
+    )
+    DELETE FROM cve_account_data WHERE (cve_id, rh_account_id) NOT IN (SELECT cve_id, rh_account_id FROM current_counts);
+  END;
+$refresh_all_cached_counts$
+  LANGUAGE 'plpgsql';
+
+CREATE OR REPLACE FUNCTION refresh_account_cached_counts(rh_account_in varchar)
+  RETURNS void AS
+$refresh_account_cached_counts$
+  DECLARE
+    rh_account_id_in INT;
+  BEGIN
+    -- update cve count for ordered systems
+    SELECT id FROM rh_account WHERE name = rh_account_in INTO rh_account_id_in;
+    WITH to_update_systems AS (
+      SELECT sp.id
+      FROM system_platform sp
+      WHERE sp.rh_account_id = rh_account_id_in
+      ORDER BY sp.id
+      FOR UPDATE OF sp
+    )
+    UPDATE system_platform sp SET cve_count_cache = (
+      SELECT COUNT(cve_id) FROM system_vulnerabilities sv LEFT OUTER JOIN
+                                insights_rule ir ON sv.rule_id = ir.id
+      WHERE sv.system_id = sp.id AND (sv.when_mitigated IS NULL OR ir.active = 'T')
+    )
+    FROM to_update_systems
+    WHERE sp.id = to_update_systems.id;
+
+    -- update system count for ordered cves
+    WITH locked_rows AS (
+      SELECT cad.cve_id
+      FROM cve_account_data cad
+      WHERE cad.rh_account_id = rh_account_id_in
+      ORDER BY cad.cve_id
+      FOR UPDATE OF cad
+    ), current_counts AS (
+      SELECT sv.cve_id, count(sv.system_id) as systems_affected
+      FROM system_vulnerabilities sv INNER JOIN
+           system_platform sp ON sv.system_id = sp.id LEFT OUTER JOIN
+           insights_rule ir ON sv.rule_id = ir.id
+      WHERE sp.when_deleted IS NULL AND
+            (sp.last_evaluation IS NOT NULL OR sp.advisor_evaluated IS NOT NULL) AND
+            (sp.opt_out = FALSE AND sp.stale = FALSE) AND
+            (sv.when_mitigated IS NULL OR
+            ir.active = 'T') AND
+            sp.rh_account_id = rh_account_id_in
+      GROUP BY sv.cve_id
+    ), upserted AS (
+      INSERT INTO cve_account_data (cve_id, rh_account_id, systems_affected)
+        SELECT cve_id, rh_account_id_in, systems_affected FROM current_counts
+      ON CONFLICT (cve_id, rh_account_id) DO UPDATE SET
+        systems_affected = EXCLUDED.systems_affected
+    )
+    DELETE FROM cve_account_data WHERE cve_id NOT IN (SELECT cve_id FROM current_counts)
+      AND rh_account_id = rh_account_id_in;
+  END;
+$refresh_account_cached_counts$
+  LANGUAGE 'plpgsql';
+
+CREATE OR REPLACE FUNCTION refresh_cve_cached_counts(cve_in varchar)
+  RETURNS void AS
+$refresh_cve_cached_counts$
+  DECLARE
+    cve_md_id INT;
+  BEGIN
+    -- update system count for cve
+    SELECT id FROM cve_metadata WHERE cve = cve_in INTO cve_md_id;
+    WITH locked_rows AS (
+      SELECT cad.rh_account_id
+      FROM cve_account_data cad
+      WHERE cad.cve_id = cve_md_id
+      ORDER BY cad.rh_account_id
+      FOR UPDATE OF cad
+    ), current_counts AS (
+      SELECT sp.rh_account_id, count(sv.system_id) as systems_affected
+      FROM system_vulnerabilities sv INNER JOIN
+           system_platform sp ON sv.system_id = sp.id LEFT OUTER JOIN
+           insights_rule ir ON sv.rule_id = ir.id
+      WHERE sp.when_deleted IS NULL AND
+            (sp.last_evaluation IS NOT NULL OR sp.advisor_evaluated IS NOT NULL) AND
+            (sp.opt_out = FALSE AND sp.stale = FALSE) AND
+            (sv.when_mitigated IS NULL OR
+            ir.active = 'T') AND
+            sv.cve_id = cve_md_id
+      GROUP BY sp.rh_account_id
+    ), upserted AS (
+      INSERT INTO cve_account_data (cve_id, rh_account_id, systems_affected)
+        SELECT cve_md_id, rh_account_id, systems_affected FROM current_counts
+      ON CONFLICT (cve_id, rh_account_id) DO UPDATE SET
+        systems_affected = EXCLUDED.systems_affected
+    )
+    DELETE FROM cve_account_data WHERE rh_account_id NOT IN (SELECT rh_account_id FROM current_counts)
+      AND cve_id = cve_md_id;
+  END;
+$refresh_cve_cached_counts$
+  LANGUAGE 'plpgsql';
+
+CREATE OR REPLACE FUNCTION refresh_cve_account_cached_counts(cve_in varchar, rh_account_in varchar)
+  RETURNS void AS
+$refresh_cve_account_cached_counts$
+  DECLARE
+    cve_md_id INT;
+    rh_account_id_in INT;
+  BEGIN
+    -- update system count for ordered cves
+    SELECT id FROM cve_metadata WHERE cve = cve_in INTO cve_md_id;
+    SELECT id FROM rh_account WHERE name = rh_account_in INTO rh_account_id_in;
+    WITH locked_rows AS (
+      SELECT cad.rh_account_id, cad.cve_id
+      FROM cve_account_data cad
+      WHERE cad.cve_id = cve_md_id AND
+            cad.rh_account_id = rh_account_id_in
+      FOR UPDATE OF cad
+    ), current_counts AS (
+      SELECT sv.cve_id, sp.rh_account_id, count(sv.system_id) as systems_affected
+      FROM system_vulnerabilities sv INNER JOIN
+           system_platform sp ON sv.system_id = sp.id LEFT OUTER JOIN
+           insights_rule ir ON sv.rule_id = ir.id
+      WHERE sp.when_deleted IS NULL AND
+            (sp.last_evaluation IS NOT NULL OR sp.advisor_evaluated IS NOT NULL) AND
+            (sp.opt_out = FALSE AND sp.stale = FALSE) AND
+            (sv.when_mitigated IS NULL OR
+            ir.active = 'T') AND
+            sv.cve_id = cve_md_id AND
+            sp.rh_account_id = rh_account_id_in
+      GROUP BY sv.cve_id, sp.rh_account_id
+    ), upserted AS (
+      INSERT INTO cve_account_data (cve_id, rh_account_id, systems_affected)
+        SELECT cve_md_id, rh_account_id_in, systems_affected FROM current_counts
+      ON CONFLICT (cve_id, rh_account_id) DO UPDATE SET
+        systems_affected = EXCLUDED.systems_affected
+    )
+    DELETE FROM cve_account_data WHERE NOT EXISTS (SELECT 1 FROM current_counts)
+      AND cve_id = cve_md_id
+      AND rh_account_id = rh_account_id_in;
+  END;
+$refresh_cve_account_cached_counts$
+  LANGUAGE 'plpgsql';

--- a/database/schema/ve_db_dev_data.sql
+++ b/database/schema/ve_db_dev_data.sql
@@ -30,6 +30,11 @@ INSERT INTO system_platform (id, inventory_id, display_name, rh_account_id, s3_u
 (10, 'INV-10', 'inv-0.redhat.com', 1, 'https://s3/10', '{ "package_list": [ "kernel-2.6.32-696.20.1.el6.x86_64" ]}', '1', '2018-09-22 12:00:00-04', '2018-09-22 12:00:00-04'),
 (11, 'INV-11', 'inv-0.ibm.com', 2, 'https://s3/11', '{ "package_list": [ "kernel-2.6.32-696.20.1.el6.x86_64" ]}', '1', '2018-09-22 12:00:00-04', '2018-09-22 12:00:00-04');
 
+INSERT INTO system_platform (id, inventory_id, display_name, rh_account_id, s3_url, vmaas_json, json_checksum, last_upload, last_evaluation,  when_deleted) VALUES
+(12, 'INV-12', 'inv-12.example.com', 0, 'https://s3/12', '{ "package_list": [ "kernel-2.6.32-696.20.1.el6.x86_64" ]}', '1', '2018-09-22 12:00:00-04', '2018-09-22 12:00:00-04', '2018-09-23 12:00:00-04'),
+(13, 'INV-13', 'inv-13.example.com', 0, 'https://s3/13', '{ "package_list": [ "kernel-2.6.32-696.20.1.el6.x86_64" ]}', '1', '2018-09-22 12:00:00-04', '2018-09-22 12:00:00-04', '2018-09-23 12:00:00-04'),
+(14, 'INV-14', 'inv-14.example.com', 0, 'https://s3/14', '{ "package_list": [ "kernel-2.6.32-696.20.1.el6.x86_64" ]}', '1', '2018-09-22 12:00:00-04', '2018-09-22 12:00:00-04', '2018-09-23 12:00:00-04');
+
 INSERT INTO cve_metadata (id, cve, impact_id, cvss3_score, cvss3_metrics, public_date, description) VALUES
 (0, 'CVE-2013-1', 7, NULL, NULL, '2013-11-12 00:00:00+00', 'CVE-2013-1 desc'),
 (1, 'CVE-2014-1', 5, NULL, NULL, '2014-04-07 00:00:00+00', 'CVE-2014-1 desc'),
@@ -108,7 +113,12 @@ INSERT INTO system_vulnerabilities (system_id, cve_id, first_reported, when_miti
 (8, 3, '2018-04-01 12:00:00-04', NULL, 2, NULL),
 (9, 10, '2018-08-03 12:00:00-04', NULL, 5, NULL),
 (9, 2, '2018-09-01 12:00:00-04', NULL, 2, NULL),
-(9, 3, '2018-04-01 12:00:00-04', NULL, 2, NULL);
+(9, 3, '2018-04-01 12:00:00-04', NULL, 2, NULL),
+(12, 2, '2018-09-01 12:00:00-04', NULL, 2, NULL),
+(12, 3, '2018-04-01 12:00:00-04', NULL, 2, NULL),
+(13, 10, '2018-08-03 12:00:00-04', NULL, 5, NULL),
+(13, 2, '2018-09-01 12:00:00-04', NULL, 2, NULL),
+(13, 3, '2018-04-01 12:00:00-04', NULL, 2, NULL);
 
 INSERT INTO cve_account_data (cve_id, rh_account_id, business_risk_id, business_risk_text, status_id, status_text) VALUES
 (10, 1, 0, NULL, 0, 'status_text0'),

--- a/database/schema/ve_db_postgresql.sql
+++ b/database/schema/ve_db_postgresql.sql
@@ -30,7 +30,7 @@ CREATE TABLE IF NOT EXISTS db_version (
 ) TABLESPACE pg_default;
 
 -- set the schema version directly in the insert statement here!!
-INSERT INTO db_version (name, version) VALUES ('schema_version', 58);
+INSERT INTO db_version (name, version) VALUES ('schema_version', 59);
 -- INSERT INTO db_version (name, version) VALUES ('schema_version', :schema_version);
 
 
@@ -221,7 +221,8 @@ $refresh_all_cached_counts$
       FROM system_vulnerabilities sv INNER JOIN
            system_platform sp ON sv.system_id = sp.id LEFT OUTER JOIN
            insights_rule ir ON sv.rule_id = ir.id
-      WHERE (sp.last_evaluation IS NOT NULL OR sp.advisor_evaluated IS NOT NULL) AND
+      WHERE sp.when_deleted IS NULL AND
+            (sp.last_evaluation IS NOT NULL OR sp.advisor_evaluated IS NOT NULL) AND
             (sp.opt_out = FALSE AND sp.stale = FALSE) AND
             (sv.when_mitigated IS NULL OR
             ir.active = 'T')
@@ -273,7 +274,8 @@ $refresh_account_cached_counts$
       FROM system_vulnerabilities sv INNER JOIN
            system_platform sp ON sv.system_id = sp.id LEFT OUTER JOIN
            insights_rule ir ON sv.rule_id = ir.id
-      WHERE (sp.last_evaluation IS NOT NULL OR sp.advisor_evaluated IS NOT NULL) AND
+      WHERE sp.when_deleted IS NULL AND
+            (sp.last_evaluation IS NOT NULL OR sp.advisor_evaluated IS NOT NULL) AND
             (sp.opt_out = FALSE AND sp.stale = FALSE) AND
             (sv.when_mitigated IS NULL OR
             ir.active = 'T') AND
@@ -311,7 +313,8 @@ $refresh_cve_cached_counts$
       FROM system_vulnerabilities sv INNER JOIN
            system_platform sp ON sv.system_id = sp.id LEFT OUTER JOIN
            insights_rule ir ON sv.rule_id = ir.id
-      WHERE (sp.last_evaluation IS NOT NULL OR sp.advisor_evaluated IS NOT NULL) AND
+      WHERE sp.when_deleted IS NULL AND
+            (sp.last_evaluation IS NOT NULL OR sp.advisor_evaluated IS NOT NULL) AND
             (sp.opt_out = FALSE AND sp.stale = FALSE) AND
             (sv.when_mitigated IS NULL OR
             ir.active = 'T') AND
@@ -351,7 +354,8 @@ $refresh_cve_account_cached_counts$
       FROM system_vulnerabilities sv INNER JOIN
            system_platform sp ON sv.system_id = sp.id LEFT OUTER JOIN
            insights_rule ir ON sv.rule_id = ir.id
-      WHERE (sp.last_evaluation IS NOT NULL OR sp.advisor_evaluated IS NOT NULL) AND
+      WHERE sp.when_deleted IS NULL AND
+            (sp.last_evaluation IS NOT NULL OR sp.advisor_evaluated IS NOT NULL) AND
             (sp.opt_out = FALSE AND sp.stale = FALSE) AND
             (sv.when_mitigated IS NULL OR
             ir.active = 'T') AND
@@ -469,6 +473,7 @@ CREATE TABLE IF NOT EXISTS system_platform (
   stale_warning_timestamp TIMESTAMP WITH TIME ZONE,
   culled_timestamp TIMESTAMP WITH TIME ZONE,
   stale BOOLEAN NOT NULL DEFAULT FALSE,
+  when_deleted TIMESTAMP WITH TIME ZONE,
   UNIQUE (inventory_id),
   CONSTRAINT rh_account_id
     FOREIGN KEY (rh_account_id)
@@ -480,6 +485,8 @@ CREATE INDEX ON system_platform(rh_account_id);
 CREATE INDEX ON system_platform(stale);
 
 CREATE INDEX ON system_platform(stale_warning_timestamp);
+
+CREATE INDEX ON system_platform(when_deleted);
 
 CREATE TRIGGER system_platform_set_first_reported
   BEFORE INSERT ON system_platform
@@ -689,18 +696,6 @@ GRANT SELECT, INSERT, UPDATE, DELETE ON cve_account_data TO ve_db_user_advisor_l
 -- taskomatic user needs to update system_platfrom when marking system stale
 GRANT SELECT, UPDATE ON system_platform TO ve_db_user_taskomatic;
 GRANT SELECT, UPDATE, DELETE ON cve_account_data TO ve_db_user_taskomatic;
-
-
-CREATE TABLE IF NOT EXISTS deleted_systems (
-  inventory_id TEXT NOT NULL, CHECK (NOT empty(inventory_id)),
-  when_deleted TIMESTAMP WITH TIME ZONE NOT NULL,
-  UNIQUE (inventory_id)
-) TABLESPACE pg_default;
-
-CREATE INDEX ON deleted_systems(when_deleted);
-
-GRANT SELECT, INSERT, UPDATE, DELETE ON deleted_systems TO ve_db_user_listener;
-GRANT SELECT, INSERT, UPDATE, DELETE ON deleted_systems TO ve_db_user_manager;
 
 
 -- repo

--- a/evaluator/evaluator.py
+++ b/evaluator/evaluator.py
@@ -295,6 +295,7 @@ class QueueEvaluator:
                     cur.execute("""SELECT id, inventory_id, vmaas_json, rh_account_id,
                                         opt_out, stale FROM system_platform
                                 WHERE inventory_id = %s
+                                  AND when_deleted IS NULL
                                 FOR UPDATE""", (msg_dict['host']['id'],))
                     system_platform = cur.fetchone()
                     if system_platform is not None:

--- a/listener/upload_listener.py
+++ b/listener/upload_listener.py
@@ -1,7 +1,6 @@
 """Module implementing kafka listener."""
 
 import asyncio
-from datetime import datetime, timedelta
 import hashlib
 import json
 import os
@@ -13,7 +12,6 @@ import flags
 from psycopg2 import DatabaseError
 from psycopg2.extras import execute_values
 from prometheus_client import Counter, start_http_server
-import pytz
 
 from common import mqueue
 from common.bounded_executor import BoundedExecutor
@@ -71,7 +69,8 @@ REQUIRED_UPLOAD_MESSAGE_FIELDS = {
 }
 REQUIRED_EVENT_MESSAGE_FIELDS = {
     "id": [],
-    "type": []
+    "type": [],
+    "account": []
 }
 
 
@@ -116,6 +115,7 @@ def db_import_system(upload_data, vmaas_json: str, repo_list: list):
                                                                      host.get("display_name"), host.get('stale_timestamp'),
                                                                      host.get('stale_warning_timestamp'), host.get('culled_timestamp'), vmaas_json)
                 if import_status is None:
+                    conn.rollback()
                     return status
                 status |= import_status
 
@@ -136,26 +136,23 @@ def db_import_system(upload_data, vmaas_json: str, repo_list: list):
     return status
 
 
-def db_import_system_platform(cur, inventory_id: str, rh_account: str, s3_url: str, display_name: str,
-                              stale_timestamp: str, stale_warning_timestamp: str, culled_timestamp: str, vmaas_json: str):
-    """Import system_platform item to db table."""
-
-    curr_time = datetime.now(tz=pytz.utc)
-    cur.execute("""select inventory_id from deleted_systems where inventory_id = %s and when_deleted > %s""",
-                (inventory_id, curr_time - timedelta(hours=SYSTEM_DELETION_THRESHOLD, )))
-    if cur.fetchone() is not None:
-        LOGGER.warning('Received recently deleted inventory id: %s', inventory_id)
-        DELETED_UPLOADED.inc()
-        return None, None
-
+def db_account_lookup(cur, account_name):
+    """Make sure account is in DB and return row id."""
     cur.execute("""INSERT INTO rh_account (name) VALUES(%s) ON CONFLICT (name) DO NOTHING
-                RETURNING (xmax = 0) AS inserted""", (rh_account,))
+                RETURNING (xmax = 0) AS inserted""", (account_name,))
     inserted = cur.fetchone()
     if inserted:
         NEW_RH_ACCOUNT.inc()
 
-    cur.execute("""SELECT id FROM rh_account WHERE name = %s""", (rh_account,))
-    rh_account_id = cur.fetchone()[0]
+    cur.execute("""SELECT id FROM rh_account WHERE name = %s""", (account_name,))
+    account_id = cur.fetchone()[0]
+    return account_id
+
+
+def db_import_system_platform(cur, inventory_id: str, rh_account: str, s3_url: str, display_name: str,
+                              stale_timestamp: str, stale_warning_timestamp: str, culled_timestamp: str, vmaas_json: str):
+    """Import system_platform item to db table."""
+    rh_account_id = db_account_lookup(cur, rh_account)
 
     json_checksum = hashlib.sha256(vmaas_json.encode('utf-8')).hexdigest()
     # xmax is PG system column used to find out if row was inserted or updated
@@ -166,10 +163,14 @@ def db_import_system_platform(cur, inventory_id: str, rh_account: str, s3_url: s
                 ON CONFLICT (inventory_id) DO UPDATE SET
                 rh_account_id = %s, s3_url = %s, display_name = %s, vmaas_json = %s, json_checksum = %s, last_upload = CURRENT_TIMESTAMP,
                 stale_timestamp = %s, stale_warning_timestamp = %s, culled_timestamp = %s, stale = 'F'
-                RETURNING (xmax = 0) AS inserted, unchanged_since, last_evaluation, id""",
+                RETURNING (xmax = 0) AS inserted, unchanged_since, last_evaluation, id, when_deleted""",
                 (inventory_id, rh_account_id, s3_url, display_name, vmaas_json, json_checksum, stale_timestamp, stale_warning_timestamp, culled_timestamp,
                  rh_account_id, s3_url, display_name, vmaas_json, json_checksum, stale_timestamp, stale_warning_timestamp, culled_timestamp))
-    inserted, unchanged_since, last_evaluation, system_id = cur.fetchone()
+    inserted, unchanged_since, last_evaluation, system_id, when_deleted = cur.fetchone()
+    if when_deleted:
+        LOGGER.warning('Received recently deleted inventory id: %s', inventory_id)
+        DELETED_UPLOADED.inc()
+        return None, None
     if inserted:
         import_status = ImportStatus.INSERTED
         NEW_SYSTEM.inc()
@@ -240,18 +241,17 @@ def db_delete_system(msg_dict):
     with DatabasePoolConnection() as conn:
         with conn.cursor() as cur:
             try:
-                curr_time = datetime.now(tz=pytz.utc)
-                cur.execute("""INSERT INTO deleted_systems
-                            (inventory_id, when_deleted) VALUES (%s, %s)
+                rh_account_id = db_account_lookup(cur, msg_dict['account'])
+                cur.execute("""INSERT INTO system_platform
+                            (inventory_id, rh_account_id, opt_out, stale, when_deleted)
+                            VALUES (%s, %s, true, true, now())
                             ON CONFLICT (inventory_id) DO UPDATE SET
-                            when_deleted = EXCLUDED.when_deleted
-                            """, (msg_dict['id'], curr_time,))
-                cur.execute("""DELETE FROM deleted_systems WHERE when_deleted < %s
-                            """, (curr_time - timedelta(hours=SYSTEM_DELETION_THRESHOLD),))
-                cur.execute("""SELECT deleted_inventory_id FROM delete_system(%s)""", (msg_dict['id'],))
-                system_platform = cur.fetchone()
-                if system_platform is not None:
-                    rtrn['deleted'] = True
+                            opt_out = EXCLUDED.opt_out, stale = EXCLUDED.stale, when_deleted = EXCLUDED.when_deleted
+                            RETURNING (xmax = 0) AS inserted""",
+                            (msg_dict['id'], rh_account_id,))
+
+                inserted, = cur.fetchone()
+                rtrn['deleted'] = not inserted
                 conn.commit()
                 rtrn['failed'] = False
             except DatabaseError:
@@ -315,7 +315,7 @@ def process_upload(upload_data, loop=None):
             LOGGER.info('Sent message to topic %s: %s', mqueue.EVALUATOR_TOPIC,
                         json.dumps(new_upload_msg).encode("utf8"))
             sent = True
-        else:
+        elif ImportStatus.FAILED not in import_status:
             UNCHANGED_SYSTEM.inc()
             send_msg_to_payload_tracker(PAYLOAD_TRACKER_PRODUCER, upload_data, 'success',
                                         status_msg='unchanged system and not evaluated', loop=loop)

--- a/listener/upload_listener.py
+++ b/listener/upload_listener.py
@@ -27,7 +27,6 @@ PROMETHEUS_PORT = os.getenv('PROMETHEUS_PORT', '8086')
 # number of worker threads
 WORKER_THREADS = int(os.getenv('WORKER_THREADS', '30'))
 MAX_QUEUE_SIZE = int(os.getenv('MAX_QUEUE_SIZE', '30'))
-SYSTEM_DELETION_THRESHOLD = int(os.getenv('SYSTEM_DELETION_THRESHOLD', '24'))  # 24 hours
 DISABLE_OPTIMISATION = strtobool(os.getenv('DISABLE_OPTIMISATION', 'False'))
 
 # prometheus metrics

--- a/manager/cve_handler.py
+++ b/manager/cve_handler.py
@@ -53,7 +53,9 @@ class AffectedSystemsView(ListView):
             .where(CveMetadata.cve == synopsis)
             .where(RHAccount.name == query_args['rh_account_number'])
             .where((SystemVulnerabilities.when_mitigated.is_null(True)) | (InsightsRule.active == True))
-            .where((SystemPlatform.opt_out == False) & (SystemPlatform.stale == False))  # noqa: E712
+            .where((SystemPlatform.opt_out == False)  # noqa: E712
+                   & (SystemPlatform.stale == False)  # noqa: E712
+                   & (SystemPlatform.when_deleted.is_null(True)))
         )
 
         if 'status_id' in filter_args and filter_args['status_id']:
@@ -167,7 +169,9 @@ class GetCves(GetRequest):
             .where(CveMetadata.cve == synopsis)
             .where(RHAccount.name == connexion.context['user'])
             .where((SystemVulnerabilities.when_mitigated.is_null(True)) | (InsightsRule.active == True))
-            .where((SystemPlatform.opt_out == False) & (SystemPlatform.stale == False))  # noqa: E712
+            .where((SystemPlatform.opt_out == False)  # noqa: E712
+                   & (SystemPlatform.stale == False)  # noqa: E712
+                   & (SystemPlatform.when_deleted.is_null(True)))
             .group_by(SystemVulnerabilities.status)
             .dicts()
         )
@@ -350,7 +354,9 @@ class PatchCveStatus(PatchRequest):
                              .join(SystemPlatform, on=(SystemVulnerabilities.system_id == SystemPlatform.id))
                              .join(InsightsRule, JOIN.LEFT_OUTER, on=(InsightsRule.id == SystemVulnerabilities.rule_id))
                              .where(SystemPlatform.rh_account_id == rh_account[0].id)
-                             .where(SystemPlatform.opt_out == False)  # noqa: E712
+                             .where((SystemPlatform.opt_out == False)  # noqa: E712
+                                    & (SystemPlatform.stale == False)  # noqa: E712
+                                    & (SystemPlatform.when_deleted.is_null(True)))
                              .where(SystemVulnerabilities.cve_id == cve.id)
                              .where((SystemVulnerabilities.when_mitigated.is_null(True)) | (InsightsRule.active == True))
                              .where(SystemVulnerabilities.status_id != values.get('status_id', 0))

--- a/manager/report_handler.py
+++ b/manager/report_handler.py
@@ -51,7 +51,7 @@ class GetExecutive(GetRequest):
         rh_account = rh_account.id
         retval['system_count'] = SystemPlatform.select(fn.COUNT(SystemPlatform.id).alias('count')).where(
             (SystemPlatform.rh_account_id == rh_account) & ((SystemPlatform.last_evaluation.is_null(False)) | (SystemPlatform.advisor_evaluated.is_null(False)))
-            & ((SystemPlatform.opt_out == False) & (SystemPlatform.stale == False))).first().count  # noqa: E712
+            & ((SystemPlatform.opt_out == False) & (SystemPlatform.stale == False) & (SystemPlatform.when_deleted.is_null(True)))).first().count  # noqa: E712
         if retval['system_count'] == 0:
             return retval
         cves_total = CveAccountData.select(CveAccountData.cve_id).where((CveAccountData.rh_account_id == rh_account) & (CveAccountData.systems_affected > 0))

--- a/manager/status_handler.py
+++ b/manager/status_handler.py
@@ -92,7 +92,9 @@ class PatchStatus(PatchRequest):
                       .join(SystemPlatform, on=(SystemVulnerabilities.system_id == SystemPlatform.id))
                       .join(InsightsRule, JOIN.LEFT_OUTER, on=(InsightsRule.id == SystemVulnerabilities.rule_id))
                       .where(SystemPlatform.rh_account_id == rh_account_id)
-                      .where(SystemPlatform.opt_out == False)  # noqa: E712
+                      .where((SystemPlatform.opt_out == False)  # noqa: E712
+                             & (SystemPlatform.stale == False)  # noqa: E712
+                             & (SystemPlatform.when_deleted.is_null(True)))
                       .where(SystemVulnerabilities.cve_id << cve_ids)
                       .where((SystemVulnerabilities.when_mitigated.is_null(True)) | (InsightsRule.active == True))
                       .where(SystemVulnerabilities.status_id != fn.COALESCE(
@@ -128,7 +130,9 @@ class PatchStatus(PatchRequest):
             rh_account = get_or_create_account()
             systems = (SystemPlatform.select(SystemPlatform.id)
                        .where((SystemPlatform.rh_account_id == rh_account[0].id) &
-                              (SystemPlatform.opt_out == False)))  # noqa: E712
+                              (SystemPlatform.opt_out == False) &  # noqa: E712
+                              (SystemPlatform.stale == False) &  # noqa: E712
+                              (SystemPlatform.when_deleted.is_null(True))))
             if in_inventory_id_list is not None:
                 systems = systems.where(SystemPlatform.inventory_id << in_inventory_id_list)
             rows_modified = set()

--- a/manager/system_handler.py
+++ b/manager/system_handler.py
@@ -57,6 +57,7 @@ class SystemCvesView(ListView):
             .where(RHAccount.name == query_args['rh_account_number'])
             .where(SystemPlatform.inventory_id == query_args['inventory_id'])
             .where(SystemPlatform.opt_out == False)  # noqa: E712
+            .where(SystemPlatform.when_deleted.is_null(True))
         )
         if 'cvss_from' in filter_args and filter_args['cvss_from']:
             query = query.where(fn.COALESCE(CveMetadata.cvss3_score, CveMetadata.cvss2_score) >= filter_args['cvss_from'])
@@ -128,6 +129,7 @@ class SystemView(ListView):
             .join(RHAccount, on=(RHAccount.id == SystemPlatform.rh_account_id))
             .where(RHAccount.name == query_args['rh_account_number'])
             .where(SystemPlatform.last_evaluation.is_null(False) | SystemPlatform.advisor_evaluated.is_null(False))
+            .where(SystemPlatform.when_deleted.is_null(True))
             .dicts()
         )
         if 'opt_out' in filter_args and filter_args['opt_out']:
@@ -224,6 +226,7 @@ class GetSystemsCves(GetRequest):
                       .join(RHAccount, on=(SystemPlatform.rh_account_id == RHAccount.id))
                       .where(SystemPlatform.inventory_id == inventory_id)
                       .where(RHAccount.name == connexion.context['user'])
+                      .where(SystemPlatform.when_deleted.is_null(True))
                       .get())
         except DoesNotExist:
             raise ApplicationException('inventory_id must exist and inventory_id must be visible to user', 404)
@@ -291,6 +294,7 @@ class GetSystemDetails(GetRequest):
                       .where(SystemPlatform.inventory_id == inventory_id)
                       .where(RHAccount.name == connexion.context['user'])
                       .where(SystemPlatform.stale == stale)
+                      .where(SystemPlatform.when_deleted.is_null(True))
                       .get())
         except DoesNotExist:
             raise ApplicationException('inventory_id must exist and inventory_id must be visible to user', 404)
@@ -312,7 +316,8 @@ class PatchSystemsOptOut(PatchRequest):
                   .where(((RHAccount.select(RHAccount.id)
                            .where(RHAccount.name == connexion.context['user'])
                            .get()).id == SystemPlatform.rh_account_id) &
-                         (SystemPlatform.inventory_id == inventory_id)))
+                         (SystemPlatform.inventory_id == inventory_id) &
+                         (SystemPlatform.when_deleted.is_null(True))))
         rows_affected = update.execute()
         if rows_affected == 0:
             raise ApplicationException('inventory_id must exist and inventory_id must be visible to user', 404)
@@ -340,7 +345,8 @@ class PatchBulkSystemsOptOut(PatchRequest):
                   .where(((RHAccount.select(RHAccount.id)
                            .where(RHAccount.name == connexion.context['user'])
                            .get()).id == SystemPlatform.rh_account_id) &
-                         (SystemPlatform.inventory_id << system_list))
+                         (SystemPlatform.inventory_id << system_list) &
+                         (SystemPlatform.when_deleted.is_null(True)))
                   .returning(SystemPlatform))
         updated = []
         for system in update.execute():

--- a/metrics/metrics_gather.py
+++ b/metrics/metrics_gather.py
@@ -99,6 +99,9 @@ class MetricsGatherer():
                              JOIN rh_account ra
                                ON sp.rh_account_id = ra.id
                             WHERE sv.status_id != 0
+                              AND sp.opt_out = false
+                              AND sp.stale = false
+                              AND sp.when_deleted IS NULL
                          GROUP BY ra.name
                          ORDER BY count(ra.name) DESC""")
             for row in cur.fetchall():

--- a/platform_mock/platform_mock.py
+++ b/platform_mock/platform_mock.py
@@ -25,7 +25,17 @@ LOGGER = get_logger(__name__)
 STORAGE_PATH = "/tmp/storage"
 
 
-class UploadHandler(RequestHandler):
+class BaseHandler(RequestHandler):
+    """Base Handler."""
+    def _get_rh_account(self):
+        if "x-rh-identity" not in self.request.headers:
+            return "0"
+        encoded_value = self.request.headers["x-rh-identity"]
+        decoded_value = base64.b64decode(encoded_value).decode("utf-8")
+        identity = json.loads(decoded_value)
+        return identity.get("identity", {}).get("account_number", "0")
+
+class UploadHandler(BaseHandler):
     """Upload Handler."""
 
     def data_received(self, chunk):
@@ -78,14 +88,6 @@ class UploadHandler(RequestHandler):
             LOGGER.error("Unable to parse archive.")
         return profile
 
-    def _get_rh_account(self):
-        if "x-rh-identity" not in self.request.headers:
-            return "0"
-        encoded_value = self.request.headers["x-rh-identity"]
-        decoded_value = base64.b64decode(encoded_value).decode("utf-8")
-        identity = json.loads(decoded_value)
-        return identity.get("identity", {}).get("account_number", "0")
-
     def _get_upload_multiplier(self):
         if "x-upload-multiplier" not in self.request.headers:
             return 1
@@ -133,7 +135,7 @@ class UploadHandler(RequestHandler):
         self.finish()
 
 
-class DownloadHandler(RequestHandler):
+class DownloadHandler(BaseHandler):
     """Download Handler."""
 
     def data_received(self, chunk):
@@ -151,7 +153,7 @@ class DownloadHandler(RequestHandler):
         self.finish()
 
 
-class DeleteHandler(RequestHandler):
+class DeleteHandler(BaseHandler):
     """Delete Handler."""
 
     def data_received(self, chunk):
@@ -159,13 +161,14 @@ class DeleteHandler(RequestHandler):
 
     def delete(self, inventory_id):
         """Answer DELETE request."""
-        delete_message = {"type": "delete", "id": inventory_id}
+        rh_account = self._get_rh_account()
+        delete_message = {"type": "delete", "id": inventory_id, "account": rh_account}
         self.application.events_queue.send(delete_message)
         LOGGER.info("Delete: %s", delete_message)
         self.finish()
 
 
-class RbacHandler(RequestHandler):
+class RbacHandler(BaseHandler):
     """RBAC mock"""
 
     def data_received(self, chunk):
@@ -179,7 +182,7 @@ class RbacHandler(RequestHandler):
                                'data': [{'permission': 'vulnerability:*:*', 'resourceDefinitions': []}]}))
 
 
-class InsightsRulesHandler(RequestHandler):
+class InsightsRulesHandler(BaseHandler):
     """Insights rule API mock"""
 
     def data_received(self, chunk):
@@ -236,7 +239,7 @@ class InsightsRulesHandler(RequestHandler):
             }""".replace('\n', ''))
 
 
-class InventoryHandler(RequestHandler):
+class InventoryHandler(BaseHandler):
     """Inventory mock"""
 
     def data_received(self, chunk):

--- a/scripts/inventory_sync.py
+++ b/scripts/inventory_sync.py
@@ -50,9 +50,13 @@ def main():
     for acc_id, acc_name in db_accounts.items():
         if not options.culled:
             cur.execute("""SELECT inventory_id, last_upload, culled_timestamp from system_platform
-                           where rh_account_id = %s and (culled_timestamp is null or culled_timestamp > now())""", (acc_id,))
+                           where when_deleted is null and
+                           rh_account_id = %s and
+                           (culled_timestamp is null or culled_timestamp > now())""", (acc_id,))
         else:
-            cur.execute("SELECT inventory_id, last_upload, culled_timestamp from system_platform where rh_account_id = %s", (acc_id,))
+            cur.execute("""SELECT inventory_id, last_upload, culled_timestamp from system_platform
+                           where when_deleted is null and
+                           rh_account_id = %s""", (acc_id,))
         auth_header = build_auth_header(acc_name)
         headers = {
             "x-rh-identity": auth_header

--- a/taskomatic/jobs/cache_check.py
+++ b/taskomatic/jobs/cache_check.py
@@ -33,7 +33,7 @@ def check_account(cur, account_id, account_name):
         cur.execute("""SELECT count(*) from system_vulnerabilities sv
                        LEFT OUTER JOIN insights_rule ir ON sv.rule_id = ir.id
                        WHERE sv.cve_id = %(cve_id)s AND sv.system_id IN
-                       (SELECT id FROM system_platform WHERE rh_account_id = %(account_id)s AND opt_out = 'F' and stale = 'F')
+                       (SELECT id FROM system_platform WHERE rh_account_id = %(account_id)s AND when_deleted is NULL AND opt_out = 'F' and stale = 'F')
                        AND (sv.when_mitigated IS NULL OR ir.active = 'T')""",
                     {'account_id': account_id, 'cve_id': cve_id})
         real_count = cur.fetchone()[0]
@@ -41,8 +41,8 @@ def check_account(cur, account_id, account_name):
             LOGGER.error('Counts does not match for %s in org %s: %s (cached) vs. %s (real)', cve_name, account_name, systems_affected, real_count)
             passed = False
 
-    cur.execute("""SELECT id, inventory_id, cve_count_cache FROM system_platform WHERE rh_account_id = %(account_id)s AND opt_out = 'F' AND stale = 'F'""",
-                {'account_id': account_id})
+    cur.execute("""SELECT id, inventory_id, cve_count_cache FROM system_platform WHERE rh_account_id = %(account_id)s AND when_deleted is NULL
+                   AND opt_out = 'F' AND stale = 'F'""", {'account_id': account_id})
     systems = cur.fetchall()
 
     for system_id, inventory_id, cached_count in systems:

--- a/taskomatic/jobs/delete_systems.py
+++ b/taskomatic/jobs/delete_systems.py
@@ -1,0 +1,58 @@
+"""
+Periodic cleanup of deleted systems
+"""
+
+import os
+from datetime import datetime, timedelta
+
+import psycopg2
+import pytz
+
+from common.logging import get_logger, init_logging
+
+DB_NAME = os.getenv('POSTGRESQL_DATABASE')
+DB_USER = os.getenv('POSTGRESQL_USER')
+DB_PASS = os.getenv('POSTGRESQL_PASSWORD')
+DB_HOST = os.getenv('POSTGRESQL_HOST')
+DB_PORT = int(os.getenv('POSTGRESQL_PORT', '5432'))
+
+LOGGER = get_logger(__name__)
+
+SYSTEM_DELETION_THRESHOLD = int(os.getenv('SYSTEM_DELETION_THRESHOLD', '24'))  # 24 hours
+
+
+def run():
+    """Application entrypoint"""
+    LOGGER.info('Started delete_systems job.')
+
+    conn = psycopg2.connect(dbname=DB_NAME, user=DB_USER, password=DB_PASS, host=DB_HOST, port=DB_PORT)
+    cur = conn.cursor()
+    deleted = 0
+
+    while True:
+        curr_time = datetime.now(tz=pytz.utc)
+        cur.execute("""SELECT inventory_id from system_platform sp
+                       WHERE when_deleted IS NOT NULL
+                         AND when_deleted > %s
+                       LIMIT 1 FOR UPDATE OF sp""", (curr_time - timedelta(hours=SYSTEM_DELETION_THRESHOLD),))
+        inventory_id = cur.fetchone()
+        if not inventory_id:
+            break
+        cur.execute("""SELECT deleted_inventory_id FROM delete_system(%s)""", (inventory_id[0],))
+        success = cur.fetchone()
+        if success:
+            deleted += 1
+        else:
+            LOGGER.error("Unable to delete inventory_id: %s", inventory_id)
+        conn.commit()
+    cur.close()
+    conn.close()
+
+    LOGGER.info('Cleared %s deleted systems.', deleted)
+
+    LOGGER.info('Finished delete_systems job.')
+
+
+if __name__ == '__main__':
+    init_logging()
+    run()

--- a/taskomatic/jobs/stale_systems.py
+++ b/taskomatic/jobs/stale_systems.py
@@ -27,7 +27,8 @@ def run():
 
     while True:
         cur.execute("""SELECT id from system_platform sp
-                    WHERE stale_warning_timestamp IS NOT NULL
+                    WHERE when_deleted IS NULL
+                      AND stale_warning_timestamp IS NOT NULL
                       AND stale = 'F'
                       AND now() > stale_warning_timestamp LIMIT 1 FOR UPDATE OF sp""")
         system_id = cur.fetchone()

--- a/tests/data/truncate_dev_data.sql
+++ b/tests/data/truncate_dev_data.sql
@@ -1,2 +1,2 @@
-TRUNCATE TABLE system_platform, cve_metadata, system_vulnerabilities, deleted_systems,
+TRUNCATE TABLE system_platform, cve_metadata, system_vulnerabilities,
 repo, system_repo, timestamp_kv, rh_account, cve_account_data, insights_rule, cve_rule_mapping;

--- a/tests/listener_tests/test_upload_listener.py
+++ b/tests/listener_tests/test_upload_listener.py
@@ -37,7 +37,7 @@ A_SYSTEM = {'vmaas-json': 'NEW-JSON', 'host': {'id': 'NEW-ID',
                                                'stale_warning_timestamp': '2020-01-16T10:17:33.881280+00:00',
                                                'culled_timestamp': '2020-01-23T10:17:33.881280+00:00'},
             'platform_metadata': {'url': 'NEW-URL'}}
-A_SYSTEM_DELETE = {'id': 'NEW-ID'}
+A_SYSTEM_DELETE = {'id': 'NEW-ID', 'account': 'NEW-ACCT'}
 
 
 class TestUploadListner:
@@ -153,23 +153,21 @@ class TestUploadListner:
             assert rtrn['deleted']
             assert not rtrn['failed']
 
-            # try to delete it again
+            # and again, same result, because the record in system_platform still exists
             rtrn = db_delete_system(A_SYSTEM_DELETE)
-            assert not rtrn['deleted']
+            assert rtrn['deleted']
             assert not rtrn['failed']
 
-            # try to delete system with invalid id
-            with caplog.at_level(logging.ERROR):
-                rtrn = db_delete_system({'id': 0})
+            # try to delete system with non-existing id
+            rtrn = db_delete_system({'id': '0', 'account': 'NEW-ACCT'})
             assert not rtrn['deleted']
-            assert rtrn['failed']
-            assert caplog.records[0].msg.startswith("Error deleting system:")
+            assert not rtrn['failed']
             caplog.clear()
 
     def test_process_delete(self, pg_db_conn, caplog):  # pylint: disable=unused-argument
         """Test deleting a system."""
 
-        msg_dict = {'id': A_SYSTEM_DELETE['id'] + '1'}
+        msg_dict = {'id': A_SYSTEM_DELETE['id'] + '1', 'account': A_SYSTEM_DELETE['account']}
 
         with DatabasePool(1):
             # make sure system is in DB
@@ -181,12 +179,6 @@ class TestUploadListner:
             with caplog.at_level(logging.INFO):
                 process_delete(msg_dict)
             assert caplog.records[0].msg.startswith("Deleted system with inventory_id:")
-            caplog.clear()
-
-            # try to delete the system again
-            with caplog.at_level(logging.INFO):
-                process_delete(msg_dict)
-            assert caplog.records[0].msg.startswith("Unable to delete system, inventory_id not found:")
             caplog.clear()
 
             with caplog.at_level(logging.WARNING):

--- a/vmaas_sync/vmaas_sync.py
+++ b/vmaas_sync/vmaas_sync.py
@@ -272,8 +272,9 @@ class ServerApplication(Application):
     def select_repo_based_inventory_ids(cur, repos: list):
         """Select inventory-ids connected with inserted repos, don't fetch it."""
         if repos:
-            cur.execute("""select inventory_id from system_platform where id in
-                           (select distinct system_id from system_repo where repo_id in
+            cur.execute("""select inventory_id from system_platform where
+                           when_deleted is null and
+                           id in (select distinct system_id from system_repo where repo_id in
                            (select id from repo where name in %s))""", (tuple(repos),))
         else:
             cur.execute("""select * from system_repo where (1=0)""")  # ensure empty result
@@ -281,7 +282,7 @@ class ServerApplication(Application):
     @staticmethod
     def select_all_inventory_ids(cur):
         """Select all inventory-ids, don't fetch it."""
-        cur.execute("select inventory_id from system_platform")
+        cur.execute("select inventory_id from system_platform where when_deleted is null")
 
     @staticmethod
     def get_last_repobased_eval_tms(cur):


### PR DESCRIPTION
problems with current implementation:
- there is no guarancy that system is correctly imported or deleted when it's deleted shortly after upload
- listener and advisor-listener check deleted_systems table but it doesn't have any effect because other thread/pod can delete the system imediately after they check it
- there are orphaned systems in DB but missing in inventory

fix:
- remove deleted_systems table, use only system_platform for better insert/delete concurrency handling
- do not remove immediately, remember for 24h and remove by taskomatic