### PR TITLE
chore: pipenv check workaround

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -18,6 +18,8 @@ WORKDIR /engine
 
 ENV LC_ALL=en_US.utf8
 ENV LANG=en_US.utf8
+ARG PIPENV_CHECK=1
+ARG PIPENV_PYUP_API_KEY=""
 RUN pipenv install --ignore-pipfile --deploy && ln -s /usr/bin/python3 /usr/bin/python && \
     if [ "${PIPENV_CHECK}" == 1 ] ; then pipenv check --system ; fi
 

--- a/advisor_listener/Dockerfile
+++ b/advisor_listener/Dockerfile
@@ -13,6 +13,7 @@ ADD /advisor_listener/Pipfile*        /advisor_listener/
 ENV LC_ALL=C.utf8
 ENV LANG=C.utf8
 ARG PIPENV_CHECK=1
+ARG PIPENV_PYUP_API_KEY=""
 RUN pip3 install --upgrade pipenv && \
     pipenv install --ignore-pipfile --deploy --system && ln -s /usr/bin/python3 /usr/bin/python && \
     if [ "${PIPENV_CHECK}" == 1 ] ; then pipenv check --system ; fi

--- a/evaluator/Dockerfile
+++ b/evaluator/Dockerfile
@@ -13,6 +13,7 @@ ADD /evaluator/Pipfile*        /evaluator/
 ENV LC_ALL=C.utf8
 ENV LANG=C.utf8
 ARG PIPENV_CHECK=1
+ARG PIPENV_PYUP_API_KEY=""
 RUN pip3 install --upgrade pipenv && \
     pipenv install --ignore-pipfile --deploy --system && ln -s /usr/bin/python3 /usr/bin/python && \
     if [ "${PIPENV_CHECK}" == 1 ] ; then pipenv check --system ; fi

--- a/listener/Dockerfile
+++ b/listener/Dockerfile
@@ -13,6 +13,7 @@ ADD /listener/Pipfile*        /listener/
 ENV LC_ALL=C.utf8
 ENV LANG=C.utf8
 ARG PIPENV_CHECK=1
+ARG PIPENV_PYUP_API_KEY=""
 RUN pip3 install --upgrade pipenv && \
     pipenv install --ignore-pipfile --deploy --system && ln -s /usr/bin/python3 /usr/bin/python && \
     if [ "${PIPENV_CHECK}" == 1 ] ; then pipenv check --system ; fi

--- a/manager/Dockerfile
+++ b/manager/Dockerfile
@@ -26,6 +26,7 @@ ADD /manager/Pipfile*                      /manager/
 ENV LC_ALL=C.utf8
 ENV LANG=C.utf8
 ARG PIPENV_CHECK=1
+ARG PIPENV_PYUP_API_KEY=""
 RUN pip3 install --upgrade pipenv && \
     pipenv install --ignore-pipfile --deploy --system && ln -s /usr/bin/python3 /usr/bin/python && \
     if [ "${PIPENV_CHECK}" == 1 ] ; then pipenv check --system ; fi

--- a/metrics/Dockerfile
+++ b/metrics/Dockerfile
@@ -9,6 +9,7 @@ ADD /metrics/Pipfile*    /metrics/
 ENV LC_ALL=C.utf8
 ENV LANG=C.utf8
 ARG PIPENV_CHECK=1
+ARG PIPENV_PYUP_API_KEY=""
 RUN pip3 install --upgrade pipenv && \
     pipenv install --ignore-pipfile --deploy --system && ln -s /usr/bin/python3 /usr/bin/python && \
     if [ "${PIPENV_CHECK}" == 1 ] ; then pipenv check --system ; fi

--- a/platform_mock/Dockerfile
+++ b/platform_mock/Dockerfile
@@ -9,6 +9,7 @@ ADD /platform_mock/Pipfile*        /platform_mock/
 ENV LC_ALL=C.utf8
 ENV LANG=C.utf8
 ARG PIPENV_CHECK=1
+ARG PIPENV_PYUP_API_KEY=""
 RUN pip3 install --upgrade pipenv && \
     pipenv install --ignore-pipfile --deploy --system && ln -s /usr/bin/python3 /usr/bin/python && \
     if [ "${PIPENV_CHECK}" == 1 ] ; then pipenv check --system ; fi

--- a/scripts/openshift-debugger/Dockerfile
+++ b/scripts/openshift-debugger/Dockerfile
@@ -26,6 +26,7 @@ ADD /common/logging.py                   /debugger/common/
 ENV LC_ALL=C.utf8
 ENV LANG=C.utf8
 ARG PIPENV_CHECK=1
+ARG PIPENV_PYUP_API_KEY=""
 RUN pip3 install --upgrade pipenv && \
     pipenv install --ignore-pipfile --deploy --system && ln -s /usr/bin/python3 /usr/bin/python && \
     if [ "${PIPENV_CHECK}" == 1 ] ; then pipenv check --system ; fi

--- a/taskomatic/Dockerfile
+++ b/taskomatic/Dockerfile
@@ -13,6 +13,7 @@ ADD /taskomatic/Pipfile* /taskomatic/
 ENV LC_ALL=C.utf8
 ENV LANG=C.utf8
 ARG PIPENV_CHECK=1
+ARG PIPENV_PYUP_API_KEY=""
 RUN pip3 install --upgrade pipenv && \
     pipenv install --ignore-pipfile --deploy --system && ln -s /usr/bin/python3 /usr/bin/python && \
     if [ "${PIPENV_CHECK}" == 1 ] ; then pipenv check --system ; fi

--- a/vmaas_sync/Dockerfile
+++ b/vmaas_sync/Dockerfile
@@ -13,6 +13,7 @@ ADD /vmaas_sync/Pipfile*        /vmaas_sync/
 ENV LC_ALL=C.utf8
 ENV LANG=C.utf8
 ARG PIPENV_CHECK=1
+ARG PIPENV_PYUP_API_KEY=""
 RUN pip3 install --upgrade pipenv && \
     pipenv install --ignore-pipfile --deploy --system && ln -s /usr/bin/python3 /usr/bin/python && \
     if [ "${PIPENV_CHECK}" == 1 ] ; then pipenv check --system ; fi


### PR DESCRIPTION
https://github.com/pypa/pipenv/issues/4188

PIPENV_PYUP_API_KEY= can be removed when pipenv-2020.X.X is released