### PR TITLE
create API for retrieving only IDs of systems affected by CVE

### DIFF
--- a/manager.spec.yaml
+++ b/manager.spec.yaml
@@ -100,6 +100,45 @@ paths:
             type: string
           example: CVE_2018_3639_cpu_kernel
 
+  /v1/cves/{cve_id}/affected_systems/ids:
+    get:
+      summary: IDs of affected systems for a given CVE.
+      description: Report of IDs of affected systems for a given CVE.
+      operationId: manager.cve_handler.GetCvesAffectedSystemsIds.get
+      x-methodName: getAffectedSystemsIdsByCve
+      security:
+        - ApiKeyAuth: []
+        - BasicAuth: []
+      responses:
+        200:
+          description: Report of IDs of affected systems for a given CVE.
+          content:
+            application/vnd.api+json:
+              schema:
+                $ref: '#/components/schemas/AffectedSystemsIdsOut'
+        404:
+          description: Given CVE does not exist.
+          content:
+            application/vnd.api+json:
+              schema:
+                $ref: '#/components/schemas/Errors'
+      parameters:
+        - $ref: '#/components/parameters/filter'
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
+        - $ref: '#/components/parameters/page'
+        - $ref: '#/components/parameters/page_size'
+        - $ref: '#/components/parameters/sort'
+        - $ref: '#/components/parameters/cve_id'
+        - $ref: '#/components/parameters/status_id'
+        - $ref: '#/components/parameters/data_format'
+        - in: query
+          name: security_rule
+          description: Filter by presence (boolean) or name (string) of security rule.
+          schema:
+            type: string
+          example: CVE_2018_3639_cpu_kernel
+
   /v1/cves/business_risk:
     patch:
       summary: Set business risk for a CVE.
@@ -1146,6 +1185,27 @@ components:
                   - id
                   - type
                   - attributes
+        links:
+          $ref: '#/components/schemas/Links'
+        meta:
+          $ref: '#/components/schemas/MetaAffectedSystems'
+      required:
+        - data
+        - links
+        - meta
+
+    AffectedSystemsIdsOut:
+      type: object
+      properties:
+        data:
+          oneOf:
+            - type: string
+              description: CSV export of the JSON.
+            - type: array
+              items:
+                type: string
+                description: Host id.
+                example: INV-ID-0000-1234
         links:
           $ref: '#/components/schemas/Links'
         meta:

--- a/manager/cve_handler.py
+++ b/manager/cve_handler.py
@@ -23,7 +23,7 @@ LOGGER = get_logger(__name__)
 class AffectedSystemsView(ListView):
     """Database select for /cves API endpoint"""
 
-    def __init__(self, synopsis, list_args, query_args, filter_args, parsed_args, uri):
+    def __init__(self, synopsis, list_args, query_args, filter_args, parsed_args, uri, ids_only=False):
         # pylint: disable=singleton-comparison
         query = (
             SystemVulnerabilities
@@ -56,7 +56,7 @@ class AffectedSystemsView(ListView):
             .where((SystemPlatform.opt_out == False)  # noqa: E712
                    & (SystemPlatform.stale == False)  # noqa: E712
                    & (SystemPlatform.when_deleted.is_null(True)))
-        )
+        ) if not ids_only else self._id_query(synopsis, query_args)
 
         if 'status_id' in filter_args and filter_args['status_id']:
             query = query.where(Status.id << filter_args['status_id'])
@@ -87,6 +87,25 @@ class AffectedSystemsView(ListView):
         }
         super(AffectedSystemsView, self).__init__(query, sortable_columns, default_sort_columns,
                                                   filterable_columns, list_args, parsed_args, uri)
+
+    @staticmethod
+    def _id_query(synopsis, query_args):
+        # pylint: disable=singleton-comparison
+        return (
+            SystemVulnerabilities
+            .select(SystemPlatform.inventory_id)
+            .join(SystemPlatform, on=(SystemVulnerabilities.system_id == SystemPlatform.id))
+            .join(Status, on=(SystemVulnerabilities.status_id == Status.id))
+            .join(CveMetadata, on=(SystemVulnerabilities.cve_id == CveMetadata.id))
+            .join(RHAccount, on=(SystemPlatform.rh_account_id == RHAccount.id))
+            .join(InsightsRule, JOIN.LEFT_OUTER, on=(InsightsRule.id == SystemVulnerabilities.rule_id))
+            .where(CveMetadata.cve == synopsis)
+            .where(RHAccount.name == query_args['rh_account_number'])
+            .where((SystemVulnerabilities.when_mitigated.is_null(True)) | (InsightsRule.active == True))
+            .where((SystemPlatform.opt_out == False)  # noqa: E712
+                   & (SystemPlatform.stale == False)  # noqa: E712
+                   & (SystemPlatform.when_deleted.is_null(True)))
+        )
 
 
 class GetCves(GetRequest):
@@ -190,6 +209,7 @@ class GetCvesAffectedSystems(GetRequest):
     """GET to /v1/cves/{cve_id}/affected_systems"""
 
     _endpoint_name = r'/v1/cves/{cve_id}/affected_systems'
+    _ids_only = False
 
     @staticmethod
     def _cve_exists(synopsis):
@@ -218,40 +238,48 @@ class GetCvesAffectedSystems(GetRequest):
         list_arguments = cls._parse_list_arguments(kwargs)
         asys_view = AffectedSystemsView(synopsis,
                                         list_arguments, {"rh_account_number": connexion.context['user']},
-                                        args, args, connexion.request.path)
+                                        args, args, connexion.request.path, cls._ids_only)
 
         response = {}
         result = []
         for sys in asys_view:
-            record = {}
-            # TODO:
-            # result prob can be just {'type':'system', 'id':<inventory_id>}
-            record['cve_status_id'] = sys['cve_status_id']
-            record['inventory_id'] = sys['inventory_id']
-            record['display_name'] = sys['display_name']
-            record['status_id'] = sys['status_id']
-            record['status_name'] = sys['status_name']
-            record['status_text'] = sys['status_text']
-            record['last_evaluation'] = sys['last_evaluation'].isoformat() if sys['last_evaluation'] else ''
-            record['rules_evaluation'] = sys['rules_evaluation'].isoformat() if sys['rules_evaluation'] else None
-            record['rule'] = {
-                'details': json.loads(sys['rule_hit_details']) if sys['rule_hit_details'] else {},
-                'resolution': {
-                    'resolution': sys['resolution_text']
-                },
-                'rule': {
-                    'description': sys['description_text'],
-                    'more_info': sys['more_info_text'],
-                    'node_id': sys['kbase_node_id'],
-                    'reason': sys['reason_text'],
-                    'rule_id': sys['rule_id'],
-                }
-            } if sys['rule_active'] else None
-            result.append({'type': 'system', 'id': sys['inventory_id'], 'attributes': record})
+            if cls._ids_only:
+                result.append(sys['inventory_id'])
+            else:
+                record = {}
+                record['cve_status_id'] = sys['cve_status_id']
+                record['inventory_id'] = sys['inventory_id']
+                record['display_name'] = sys['display_name']
+                record['status_id'] = sys['status_id']
+                record['status_name'] = sys['status_name']
+                record['status_text'] = sys['status_text']
+                record['last_evaluation'] = sys['last_evaluation'].isoformat() if sys['last_evaluation'] else ''
+                record['rules_evaluation'] = sys['rules_evaluation'].isoformat() if sys['rules_evaluation'] else None
+                record['rule'] = {
+                    'details': json.loads(sys['rule_hit_details']) if sys['rule_hit_details'] else {},
+                    'resolution': {
+                        'resolution': sys['resolution_text']
+                    },
+                    'rule': {
+                        'description': sys['description_text'],
+                        'more_info': sys['more_info_text'],
+                        'node_id': sys['kbase_node_id'],
+                        'reason': sys['reason_text'],
+                        'rule_id': sys['rule_id'],
+                    }
+                } if sys['rule_active'] else None
+                result.append({'type': 'system', 'id': sys['inventory_id'], 'attributes': record})
         response['meta'] = asys_view.get_metadata()
         response['links'] = asys_view.get_pagination_links()
         response['data'] = cls._format_data(list_arguments["data_format"], result)
         return response
+
+
+class GetCvesAffectedSystemsIds(GetCvesAffectedSystems):
+    """ GET to /v1/cves/{cve_id}/affected_systems/ids """
+
+    _endpoint_name = r'/v1/cves/{cve_id}/affected_systems/ids'
+    _ids_only = True
 
 
 class PatchCveRisk(PatchRequest):

--- a/tests/manager_tests/schemas.py
+++ b/tests/manager_tests/schemas.py
@@ -206,6 +206,7 @@ _vulnerabilities_cves = {"meta": _vulnerabilities_meta, "links": _links, "data":
 _system_cves = {"meta": _system_cves_meta, "links": _links, "data": Or([_system_cve], [], str)}
 _systems = {"meta": _system_meta, "links": _links, "data": Or([_system], [], str)}
 _affected_systems = {"meta": _affected_systems_meta, "links": _links, "data": Or([_affected_system], [], str)}
+_affected_systems_ids = {"meta": _affected_systems_meta, "links": _links, "data": Or([str], [], str)}
 _impacts = {"Important": int, "Moderate": int, "Critical": int, "Low": int}
 _changes = {
     "since": Or(str, None),
@@ -251,6 +252,7 @@ cve = Schema(_cve)
 vulnerabilities_cves = Schema(_vulnerabilities_cves)
 systems = Schema(_systems)
 affected_systems = Schema(_affected_systems)
+affected_systems_ids = Schema(_affected_systems_ids)
 system_cves = Schema(_system_cves)
 system_details = Schema(_system_details)
 impacts = Schema(_impacts)
@@ -261,6 +263,7 @@ status = Schema(_bulk_change)
 
 
 SCHEMA_MAP = {
+    ("GET", "/v1/cves/.+/affected_systems/ids"): affected_systems_ids,
     ("GET", "/v1/cves/.+/affected_systems"): affected_systems,
     ("GET", "/v1/cves/CVE-"): cve,
     ("GET", "/v1/vulnerabilities/cves"): vulnerabilities_cves,

--- a/tests/manager_tests/test_cve_handler.py
+++ b/tests/manager_tests/test_cve_handler.py
@@ -9,20 +9,28 @@ class TestCveHandler(FlaskTestCase):
     def test_cves_affected_systems(self):
         response = self.vfetch("cves/CVE-2016-1/affected_systems").check_response()
         assert len(response.body.data) == 3
+        response = self.vfetch("cves/CVE-2016-1/affected_systems/ids").check_response()
+        assert len(response.body.data) == 3
 
     def test_cves_affected_systems_st_1(self):
         self.vfetch("cves/CVE-2016-1/affected_systems?status_id=2,nan").check_response(status_code=400)
+        self.vfetch("cves/CVE-2016-1/affected_systems/ids?status_id=2,nan").check_response(status_code=400)
 
     def test_cves_affected_systems_st_2(self):
         response = self.vfetch("cves/CVE-2016-1/affected_systems?status_id=1").check_response()
+        assert not response.body.data
+        response = self.vfetch("cves/CVE-2016-1/affected_systems/ids?status_id=1").check_response()
         assert not response.body.data
 
     def test_cves_affected_systems_st_3(self):
         response = self.vfetch("cves/CVE-2016-1/affected_systems?status_id=4,5,6").check_response()
         assert len(response.body.data) == 1
+        response = self.vfetch("cves/CVE-2016-1/affected_systems/ids?status_id=4,5,6").check_response()
+        assert len(response.body.data) == 1
 
     def test_invalid_cves_affected_systems(self):
         self.vfetch("cves/CVE-INVALID/affected_systems").check_response(status_code=404)
+        self.vfetch("cves/CVE-INVALID/affected_systems/ids").check_response(status_code=404)
 
     def test_cve_details(self):
         assert self.vfetch('cves/CVE-2016-1').status_code == 200
@@ -38,9 +46,17 @@ class TestCveHandler(FlaskTestCase):
     def test_cves_affected_systems_rule_filter(self):
         response = self.vfetch('cves/CVE-2017-8/affected_systems?security_rule=true').check_response()
         assert len(response.body.data) == 2
+        response = self.vfetch('cves/CVE-2017-8/affected_systems/ids?security_rule=true').check_response()
+        assert len(response.body.data) == 2
         response = self.vfetch('cves/CVE-2017-8/affected_systems?security_rule=false').check_response()
+        assert len(response.body.data) == 1
+        response = self.vfetch('cves/CVE-2017-8/affected_systems/ids?security_rule=false').check_response()
         assert len(response.body.data) == 1
 
         response = self.vfetch(
                         'cves/CVE-2017-8/affected_systems?security_rule=CVE_2018_12130_cpu_kernel|CVE_2018_12130_CPU_KERNEL_BAD_MICROCODE').check_response()
+        assert len(response.body.data) == 1
+
+        response = (self.vfetch('cves/CVE-2017-8/affected_systems/ids?security_rule=CVE_2018_12130_cpu_kernel|CVE_2018_12130_CPU_KERNEL_BAD_MICROCODE')
+                    .check_response())
         assert len(response.body.data) == 1


### PR DESCRIPTION
CVE with 17105 systems affected.
```
[02/Jun/2020:06:43:58 +0000] 200 GET /api/vulnerability/v1/cves/CVE-2019-11745/affected_systems/ids 0.503558s
[02/Jun/2020:06:44:12 +0000] 200 GET /api/vulnerability/v1/cves/CVE-2019-11745/affected_systems 3.004704s
```
On the backend side the calculation is 6 times faster.

```
[tkasparek vulnerability-engine-fork] (just_ids_api)$ time ./scripts/3scale-mock curl -X GET http://localhost:8300/api/vulnerability/v1/cves/CVE-2019-11745/affected_systems/ids?page_size=99999 > /dev/null
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  735k  100  735k    0     0  1459k      0 --:--:-- --:--:-- --:--:-- 1456k

real	0m0.550s
user	0m0.035s
sys	0m0.012s
[tkasparek vulnerability-engine-fork] (just_ids_api)$ time ./scripts/3scale-mock curl -X GET http://localhost:8300/api/vulnerability/v1/cves/CVE-2019-11745/affected_systems?page_size=99999 > /dev/null
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 8102k  100 8102k    0     0  2695k      0  0:00:03  0:00:03 --:--:-- 2695k

real	0m3.076s
user	0m0.054s
sys	0m0.018s
```
11 times less data transferred.

@jdobes please review the code and comment as at the moment the code is done in proof of concept way.