### PR TITLE
fix(evaluator): use correct condition for increasing CVE counts

### DIFF
--- a/evaluator/evaluator.py
+++ b/evaluator/evaluator.py
@@ -241,9 +241,7 @@ async def evaluate_vmaas(system_platform, conn):
             if system_cves_map[cve]['when_mitigated']:
                 # it was mitigated, now its not
                 unmitigated_cves_ids.add(system_cves_map[cve]['cve_id'])
-                # This (below) may need to be 'if not' as that was the behavior
-                # prior to 54c934fea3088c8ac09ba73802e578e7256e9fa8
-                if system_cves_map[cve]['active_rule']:  # unmitigated only if there wasn't rule hit before
+                if not system_cves_map[cve]['active_rule']:  # unmitigated only if there wasn't rule hit before
                     inc_cves_ids.add(system_cves_map[cve]['cve_id'])
         else:
             new_cves.add(cve)


### PR DESCRIPTION
54c934fea3088c8ac09ba73802e578e7256e9fa8 changed behavior
                     unmitigated_cves_ids.add(system_cves_map[cve]['cve_id'])
-                    if system_cves_map[cve]['rule_id'] is None:  # unmitigated only if there wasn't rule hit before
+                    if system_cves_map[cve]['active_rule']:  # unmitigated only if there wasn't rule hit before
                         inc_cves_ids.add(system_cves_map[cve]['cve_id'])

system_cves_map[cve]['rule_id'] is None
meant that rule wasn't present for the system CVE

system_cves_map[cve]['active_rule']
means that rule is existing for the system CVE, which inverted the
condition