### PR TITLE
chore: script for running integration tests locally

### DIFF
--- a/conf/settings.local.yaml
+++ b/conf/settings.local.yaml
@@ -1,0 +1,53 @@
+default:
+  JIRA:
+    # JIRA credentials for skipping tests failing due to existing bug
+    username: jira_username
+    password: jira_password
+  VULNERABILITY:
+    rest:
+      # internal service hostname
+      vuln_hostname: localhost
+  USERS:
+    primary_user:
+      identity:
+        account_number: "6089719"
+        type: "User"
+        user:
+          username: "jdoe"
+          email: "jdoe@acme.com"
+          first_name: "John"
+          last_name: "Doe"
+          is_active: true
+          is_org_admin: false
+          is_internal: false
+          locale: "en_US"
+        internal:
+          org_id: "3340851"
+          auth_type: "basic-auth"
+          auth_time: 6300
+      entitlements:
+        hybrid_cloud:
+          is_entitled: true
+        insights:
+          is_entitled: true
+        openshift:
+          is_entitled: true
+        smart_management:
+          is_entitled: true
+    no_entitlement:
+      username: username
+      password: password
+    invalid:
+      username: invalid
+      password: invalid
+dev:
+  main:
+    default_user: primary_user
+    hostname: localhost:8300
+    path: /
+    api_path: api
+    scheme: http
+    ssl_verify: false
+  http:
+    default_auth_type: identity
+    cacert_path: False

--- a/scripts/run_integration_tests.sh
+++ b/scripts/run_integration_tests.sh
@@ -1,0 +1,44 @@
+#/bin/bash
+
+USAGE="Usage:
+$0 [SETTINGS_YAML]
+
+Optional parameters:
+  SETTINGS_YAML - path to directory with test settings (default: conf/settings.local.yaml)
+"
+
+if [[ "$#" -gt 1 ]]; then
+    echo "$USAGE" >&2
+    exit 1
+fi
+
+[ "$(docker-compose ps | wc -l)" -gt  2 ] && docker-compose down
+cp conf/common.env conf/common.env.bak
+sed -i 's|VMAAS_HOST=http://vmaas_webapp:8080|VMAAS_HOST=https://webapp-vmaas-stable.1b13.insights.openshiftapps.com|' conf/common.env
+docker-compose up -d --build
+count=60
+while [ "$count" -gt 0 ]; do
+    engine_state=$(docker-compose ps | grep 'vulnerability-engine-manager' | awk '{print $6}')
+    [ "$engine_state" = "Up" ] && break
+    echo "Vulnerability-engine-manager is not Up, waiting 5s"
+    ((count--))
+    sleep 5
+done
+[ "$count" -gt 0 ] || exit 1
+
+docker pull quay.io/cloudservices/iqe-tests:latest
+
+if [ -n "$1" ]; then
+    settings="$1"
+else
+    settings="conf/settings.local.yaml"
+fi
+
+docker run --name iqe --rm --network host \
+    -v $(readlink -f $settings):/iqe_settings/settings.local.yaml:z \
+    -e IQE_TESTS_LOCAL_CONF_PATH=/iqe_settings \
+    -e ENV_FOR_DYNACONF=dev \
+    quay.io/cloudservices/iqe-tests:latest \
+    iqe tests plugin vulnerability -k 'rest and not basic_auth and not csaw' -v --local
+
+mv conf/common.env.bak conf/common.env


### PR DESCRIPTION
1. Login to quay.io
2 ./scripts/run_integration_tests.sh
  - script will stop currently running docker-compose, rebuild images with VMAAS_HOST set to prod, download the latest iqe-tests image from quay, and execute integration tests (except for basic_auth, e2e, and csaw tests)

**Importatnt:** To avoid 401s to JIRA, you need to provide your JIRA credentials in conf/settings.local.yaml (used for skipping tests which are blocked by an opened bug)
It looks like the evaluation is not working correctly when vulnerability is not connected to websocket (maybe due to CVE sync?), so you might need to start vmaas and sync CVEs