### PR TITLE
fix: strip newline from DB password

### DIFF
--- a/wait-for-services.sh
+++ b/wait-for-services.sh
@@ -6,6 +6,11 @@ cmd="$@"
 
 if [ ! -z "$POSTGRESQL_DATABASE" ]; then
   >&2 echo "Checking if PostgreSQL is up"
+  if [[ $POSTGRESQL_PASSWORD == *$'\n'* ]];
+    then
+      POSTGRESQL_PASSWORD=${POSTGRESQL_PASSWORD%$'\n'}
+      export POSTGRESQL_PASSWORD=$POSTGRESQL_PASSWORD
+  fi 
   until python3 -c "import psycopg2;c=psycopg2.connect(host=\"$POSTGRESQL_HOST\",database=\"$POSTGRESQL_DATABASE\",user=\"$POSTGRESQL_USER\",port=\"$POSTGRESQL_PORT\",password=\"$POSTGRESQL_PASSWORD\");c.close()" &> /dev/null; do
     >&2 echo "PostgreSQL is unavailable - sleeping"
     sleep 1


### PR DESCRIPTION
VULN-620: when listener (and others) DB password contains newline, it is not properly set to DB user
