### PR TITLE
feat(manager): split rule errkey and rule presence filtering

### DIFF
--- a/manager.spec.yaml
+++ b/manager.spec.yaml
@@ -95,9 +95,11 @@ paths:
         - $ref: '#/components/parameters/status_id'
         - $ref: '#/components/parameters/data_format'
         - $ref: '#/components/parameters/uuid'
+        - $ref: '#/components/parameters/rule_key'
+        - $ref: '#/components/parameters/rule_presence'
         - in: query
           name: security_rule
-          description: Filter by presence (boolean) or name (string) of security rule.
+          description: Filter by presence (boolean) or name (string) of security rule - Deprecated, will get obsolete, use rule_key and rule_presence.
           schema:
             type: string
           example: CVE_2018_3639_cpu_kernel|CVE_2018_3639_CPU_BAD_MICROCODE_2,CVE_2018_12207_cpu_kernel|CVE_2018_12207_CPU_KERNEL_FOR_SURE
@@ -134,9 +136,11 @@ paths:
         - $ref: '#/components/parameters/cve_id'
         - $ref: '#/components/parameters/status_id'
         - $ref: '#/components/parameters/data_format'
+        - $ref: '#/components/parameters/rule_key'
+        - $ref: '#/components/parameters/rule_presence'
         - in: query
           name: security_rule
-          description: Filter by presence (boolean) or name (string) of security rule.
+          description: Filter by presence (boolean) or name (string) of security rule - Deprecated, will get obsolete, use rule_key and rule_presence.
           schema:
             type: string
           example: CVE_2018_3639_cpu_kernel|CVE_2018_3639_CPU_BAD_MICROCODE_2,CVE_2018_12207_cpu_kernel|CVE_2018_12207_CPU_KERNEL_FOR_SURE
@@ -439,6 +443,7 @@ paths:
         - $ref: '#/components/parameters/data_format'
         - $ref: '#/components/parameters/business_risk_id'
         - $ref: '#/components/parameters/security_rule'
+        - $ref: '#/components/parameters/rule_presence'
 
   /systems/{inventory_id}/cves/ids:
     get:
@@ -479,6 +484,7 @@ paths:
         - $ref: '#/components/parameters/data_format'
         - $ref: '#/components/parameters/business_risk_id'
         - $ref: '#/components/parameters/security_rule'
+        - $ref: '#/components/parameters/rule_presence'
 
   /systems/{inventory_id}/opt_out:
     patch:
@@ -578,6 +584,7 @@ paths:
         - $ref: '#/components/parameters/business_risk_id'
         - $ref: '#/components/parameters/status_id'
         - $ref: '#/components/parameters/security_rule'
+        - $ref: '#/components/parameters/rule_presence'
         - in: query
           name: show_all
           description: Show all known vulnerabilities, regardless of number of affected systems.
@@ -617,6 +624,7 @@ paths:
         - $ref: '#/components/parameters/business_risk_id'
         - $ref: '#/components/parameters/status_id'
         - $ref: '#/components/parameters/security_rule'
+        - $ref: '#/components/parameters/rule_presence'
         - in: query
           name: show_all
           description: Show all known vulnerabilities IDs, regardless of number of affected systems.
@@ -892,10 +900,30 @@ components:
     security_rule:
       in: query
       name: security_rule
-      description: If true shows only CVEs with security rule associated, if false shows CVEs without rules. When not set shows all CVEs.
+      description: If true shows only CVEs with security rule associated, if false shows CVEs without rules. When not set shows all CVEs - Deprecated, will get obsolete, use rule_presence.
       schema:
         type: boolean
       example: true
+
+    rule_presence:
+      in: query
+      name: rule_presence
+      description: Comma seprated string with bools. If true shows only CVEs with security rule associated, if false shows CVEs without rules. true, false shows all.
+      schema:
+        type: array
+        items:
+          type: boolean
+      example: true,false
+
+    rule_key:
+      in: query
+      name: rule_key
+      description: Filters security rules by its error key.
+      schema:
+        type: array
+        items:
+          type: string
+      example: CVE_2018_3639_cpu_kernel|CVE_2018_3639_CPU_BAD_MICROCODE_2,CVE_2018_12207_cpu_kernel|CVE_2018_12207_CPU_KERNEL_FOR_SURE
 
     uuid:
       in: query
@@ -1073,6 +1101,16 @@ components:
               type: integer
               description: Total number of systems managed by vulnerability application.
               example: 25641
+            rule_presence:
+              type: string
+              description: Filter based on presence of security rule
+              example: true,false
+              nullable: true
+            security_rule:
+              type: boolean
+              description: Filter based on presence of security rule - deprecated
+              example: true
+              nullable: true
           required:
             - business_risk_id
             - cvss_from
@@ -1081,6 +1119,8 @@ components:
             - public_from
             - public_to
             - impact
+            - rule_presence
+            - security_rule
 
     MetaAffectedSystems:
       allOf:
@@ -1092,8 +1132,20 @@ components:
               description: Filer based on CVE status ID.
               example: '1,4'
               nullable: true
+            rule_key:
+              type: string
+              description: Filters security rules by its error key.
+              example: CVE_2018_3639_cpu_kernel|CVE_2018_3639_CPU_BAD_MICROCODE_2,CVE_2018_12207_cpu_kernel|CVE_2018_12207_CPU_KERNEL_FOR_SURE
+              nullable: true
+            rule_presence:
+              type: string
+              description: Filter based on presence of security rule
+              example: true,false
+              nullable: true
           required:
             - status_id
+            - rule_key
+            - rule_presence
 
     MetaSystems:
       allOf:
@@ -1143,15 +1195,20 @@ components:
               description: Filter based on impact IDs.
               example: '5,7'
               nullable: true
-            security_rule:
-              type: boolean
-              description: Filter based on presence of security rule
-              example: true
-              nullable: true
             status_id:
               type: string
               description: Filer based on CVE status ID.
               example: '1,4'
+              nullable: true
+            rule_presence:
+              type: string
+              description: Filter based on presence of security rule
+              example: true,false
+              nullable: true
+            security_rule:
+              type: boolean
+              description: Filter based on presence of security_rule - deprecated
+              example: true
               nullable: true
           required:
             - business_risk_id
@@ -1160,8 +1217,9 @@ components:
             - public_from
             - public_to
             - impact
-            - security_rule
             - status_id
+            - rule_presence
+            - security_rule
 
     MetaCvesSystems:
       allOf:

--- a/manager/base.py
+++ b/manager/base.py
@@ -505,3 +505,8 @@ def get_account_id(acc_name):
     return RHAccount.select(RHAccount.id) \
                     .where(RHAccount.name == acc_name) \
                     .first()
+
+
+def unique_bool_list(bool_list):
+    """Makes from repeating multiple values only unique bool values"""
+    return list(set(bool_list))

--- a/manager/cve_handler.py
+++ b/manager/cve_handler.py
@@ -13,7 +13,7 @@ from common.utils import str_or_none, format_datetime
 from common.peewee_model import BusinessRisk, CveAccountData, CveMetadata, DB, RHAccount, \
     Status, SystemPlatform, SystemVulnerabilities, CveImpact, InsightsRule
 from .base import ApplicationException, DEFAULT_BUSINESS_RISK, DEFAULT_STATUS, get_or_create_account, \
-    GetRequest, parse_int_list, PatchRequest, get_rules_for_cves, reporter, bool_or_rules_list
+    GetRequest, parse_int_list, PatchRequest, get_rules_for_cves, reporter, unique_bool_list, bool_or_rules_list
 from .filters import apply_filters, filter_types
 from .list_view import ListView
 
@@ -26,7 +26,8 @@ class AffectedSystemsView(ListView):
     def __init__(self, synopsis, list_args, query_args, filter_args, parsed_args, uri, ids_only=False):
         query = self._full_query(synopsis, query_args) if not ids_only else self._id_query(synopsis, query_args)
 
-        query = apply_filters(query, filter_args, [filter_types.SYSTEM_CVE_RULE, filter_types.SYSTEM_CVE_STATUS, filter_types.SYSTEM_UUID])
+        query = apply_filters(query, filter_args, [filter_types.SYSTEM_CVE_RULE, filter_types.SYSTEM_CVE_STATUS, filter_types.SYSTEM_UUID,
+                                                   filter_types.SYSTEM_CVE_RULE_PRESENCE, filter_types.SYSTEM_CVE_RULE_OLD])
 
         query = query.dicts()
 
@@ -224,7 +225,9 @@ class GetCvesAffectedSystems(GetRequest):
         cls._cve_exists(synopsis)
         args_desc = [{'arg_name': 'status_id', 'convert_func': parse_int_list},
                      {'arg_name': 'security_rule', 'convert_func': bool_or_rules_list},
-                     {'arg_name': 'uuid', 'convert_func': None}]
+                     {'arg_name': 'uuid', 'convert_func': None},
+                     {'arg_name': 'rule_presence', 'convert_func': unique_bool_list},
+                     {'arg_name': 'rule_key', 'convert_func': None}]
         args = cls._parse_arguments(kwargs, args_desc)
         list_arguments = cls._parse_list_arguments(kwargs)
         asys_view = AffectedSystemsView(synopsis,

--- a/manager/filters.py
+++ b/manager/filters.py
@@ -97,14 +97,40 @@ def _filter_cve_by_rule_presence(query, args):
         object: Modified query with CVE security rule presence filter applied
     """
     # pylint: disable=singleton-comparison
+    if 'rule_presence' in args and args['rule_presence'] is not None:
+        def bool_expr(presence_bool):
+            if presence_bool:
+                return (CveMetadata.id << CveRuleMapping.select(CveRuleMapping.cve_id)
+                        .join(InsightsRule, on=((CveRuleMapping.rule_id == InsightsRule.id) & (InsightsRule.active == True))))  # noqa: E712
+
+            return (CveMetadata.id.not_in(CveRuleMapping.select(CveRuleMapping.cve_id)
+                                          .join(InsightsRule, on=((CveRuleMapping.rule_id == InsightsRule.id)
+                                                                  & (InsightsRule.active == True)))))  # noqa: E712
+
+        if isinstance(args['rule_presence'], bool):
+            query = query.where(bool_expr(args['rule_presence']))
+        elif isinstance(args['rule_presence'], list):
+            expr = None
+            for rule_bool in args['rule_presence']:
+                expr |= bool_expr(rule_bool)
+            if expr:
+                query = query.where(expr)
+    return query
+
+
+def _filter_cve_by_rule_presence_old(query, args):
+    """
+    Filters list of CVEs based on presence of rule. Query has to contain CveMetadata, CveRuleMapping and InsightsRule tables.
+    Will get deleted later.
+    Args:
+        query (object): Query object to apply filters to
+        args (dict): Query arguemnts
+    Returns:
+        object: Modified query with CVE security rule presence filter applied
+    """
     if 'security_rule' in args and args['security_rule'] is not None:
-        if args['security_rule']:
-            query = query.where(CveMetadata.id << CveRuleMapping.select(CveRuleMapping.cve_id)
-                                .join(InsightsRule, on=((CveRuleMapping.rule_id == InsightsRule.id) & (InsightsRule.active == True))))  # noqa: E712
-        else:
-            query = query.where(CveMetadata.id.not_in(CveRuleMapping.select(CveRuleMapping.cve_id)
-                                                      .join(InsightsRule, on=((CveRuleMapping.rule_id == InsightsRule.id)
-                                                                              & (InsightsRule.active == True)))))  # noqa: E712
+        args['rule_presence'] = [args['security_rule']]
+        return _filter_cve_by_rule_presence(query, args)
     return query
 
 
@@ -197,9 +223,7 @@ def _filter_system_by_stale(query, args):
 def _filter_system_cve_by_rule(query, args):
     """
     Filters list of CVEs based on presence/name of security rule. Query has to contain left outer joined table.
-    If boolean is passed in the `args['security_rule']` filtering is done based on presence of the rule.
-    In case of string passed in the `args['security_rule']` filtering is done on match of the rule name.
-
+    Filtering is done on match of the rule name.
     Args:
         query (object): Query object to apply filters to
         args (dict): Query arguemnts
@@ -208,14 +232,59 @@ def _filter_system_cve_by_rule(query, args):
         object: Modified query with system CVE rule name filter applied
     """
     # pylint: disable=singleton-comparison
+    if 'rule_key' in args and args['rule_key'] is not None:
+        query = query.where((InsightsRule.active == True) & (InsightsRule.name << args['rule_key']))  # noqa: E712
+    return query
+
+
+def _filter_system_cve_by_rule_presence(query, args):
+    """
+    Filters CVEs if they have rules or not. Argument can be either
+    single bool, or list of bools.
+
+    Args:
+        query (object): Query object to apply filters to
+        args (dict): Query arguemnts
+    Returns:
+        object: Modified query with system CVE rule name filter applied
+    """
+    # pylint: disable=singleton-comparison
+    if 'rule_presence' in args and args['rule_presence'] is not None:
+        def bool_expr(presence_bool):
+            if presence_bool:
+                return InsightsRule.active == True  # noqa: E712
+            return (InsightsRule.active == False) | (InsightsRule.active == None)  # noqa: E712
+
+        if isinstance(args['rule_presence'], bool):
+            query.where(bool_expr(args['rule_presence']))
+        elif isinstance(args['rule_presence'], list):
+            expr = None
+            for presence_bool in args['rule_presence']:
+                expr |= bool_expr(presence_bool)
+            if expr:
+                query = query.where(expr)
+    return query
+
+
+def _filter_system_cve_by_rule_old(query, args):
+    """
+    Filters list of CVEs based on presence/name of security rule. Query has to contain left outer joined table.
+    If query is bool - is filtered by rule presence.
+    If query is string - is filtered by rule name.
+
+    Args:
+        query (object): Query object to apply filters to
+        args (dict): Query arguemnts
+    Returns:
+        object: Modified query with system CVE rule name filter applied
+    """
     if 'security_rule' in args and args['security_rule'] is not None:
         if isinstance(args['security_rule'], bool):
-            if args['security_rule']:
-                query = query.where(InsightsRule.active == True)  # noqa: E712
-            else:
-                query = query.where((InsightsRule.active == False) | (InsightsRule.active == None))  # noqa: E712
-        else:
-            query = query.where((InsightsRule.active == True) & (InsightsRule.name << args['security_rule']))  # noqa: E712
+            args['rule_presence'] = [args['security_rule']]
+            query = _filter_system_cve_by_rule_presence(query, args)
+        elif isinstance(args['security_rule'], list):
+            args['rule_key'] = args['security_rule']
+            query = _filter_system_cve_by_rule(query, args)
     return query
 
 
@@ -243,9 +312,12 @@ class filter_types(Enum):  # pylint: disable=invalid-name
     CVE_PUBLIC_DATE = _filter_cve_by_public_date
     CVE_IMPACT = _filter_cve_by_impact
     CVE_RULE_PRESENCE = _filter_cve_by_rule_presence
+    CVE_RULE_PRESENCE_OLD = _filter_cve_by_rule_presence_old
     CVE_SHOW_ALL = _filter_cve_by_show_all
     CVE_STATUS = _filter_cve_by_status
     SYSTEM_CVE_RULE = _filter_system_cve_by_rule
+    SYSTEM_CVE_RULE_OLD = _filter_system_cve_by_rule_old
+    SYSTEM_CVE_RULE_PRESENCE = _filter_system_cve_by_rule_presence
     SYSTEM_CVE_STATUS = _filter_system_cve_by_status
     SYSTEM_OPT_OUT = _filter_system_by_opt_out
     SYSTEM_STALE = _filter_system_by_stale

--- a/manager/system_handler.py
+++ b/manager/system_handler.py
@@ -10,7 +10,7 @@ from peewee import Case, DoesNotExist, fn, JOIN, SQL
 from common.peewee_model import BusinessRisk, CveAccountData, CveMetadata, SystemPlatform, \
     SystemVulnerabilities, CveImpact, Status, DB, RHAccount, InsightsRule
 from .base import ApplicationException, DEFAULT_BUSINESS_RISK, GetRequest, parse_int_list, PatchRequest, \
-    DeleteRequest, CVE_SYNOPSIS_SORT, parse_str_or_list, reporter
+    DeleteRequest, CVE_SYNOPSIS_SORT, parse_str_or_list, reporter, unique_bool_list
 from .filters import apply_filters, filter_types
 from .list_view import ListView
 
@@ -21,7 +21,8 @@ class SystemCvesView(ListView):
     def __init__(self, list_args, query_args, filter_args, parsed_args, uri, ids_only=False):
         query = self._full_query(query_args) if not ids_only else self._id_query(query_args)
         query = apply_filters(query, filter_args, [filter_types.CVE_BUSINESS_RISK, filter_types.CVE_CVSS, filter_types.CVE_IMPACT,
-                                                   filter_types.CVE_PUBLIC_DATE, filter_types.SYSTEM_CVE_STATUS, filter_types.SYSTEM_CVE_RULE])
+                                                   filter_types.CVE_PUBLIC_DATE, filter_types.SYSTEM_CVE_STATUS, filter_types.SYSTEM_CVE_RULE_PRESENCE,
+                                                   filter_types.SYSTEM_CVE_RULE_OLD])
         query = query.dicts()
 
         sortable_columns = {
@@ -241,7 +242,7 @@ class GetSystemsCves(GetRequest):
                      {'arg_name': 'status_id', 'convert_func': parse_int_list},
                      {'arg_name': 'business_risk_id', 'convert_func': parse_int_list},
                      {'arg_name': 'security_rule', 'convert_func': None},
-                     ]
+                     {'arg_name': 'rule_presence', 'convert_func': unique_bool_list}]
         args = cls._parse_arguments(kwargs, args_desc)
         list_arguments = cls._parse_list_arguments(kwargs)
 

--- a/manager/vulnerabilities_handler.py
+++ b/manager/vulnerabilities_handler.py
@@ -8,7 +8,8 @@ import connexion
 from peewee import Case, fn, JOIN, SQL
 
 from common.peewee_model import BusinessRisk, CveAccountData, CveMetadata, CveImpact, RHAccount, Status
-from .base import DEFAULT_BUSINESS_RISK, DEFAULT_STATUS, GetRequest, parse_int_list, CVE_SYNOPSIS_SORT, get_rules_for_cves, get_system_count, get_account_id
+from .base import DEFAULT_BUSINESS_RISK, DEFAULT_STATUS, GetRequest, parse_int_list, CVE_SYNOPSIS_SORT, get_rules_for_cves, get_system_count, get_account_id, \
+                  unique_bool_list
 from .filters import apply_filters, filter_types
 from .list_view import ListView
 
@@ -24,7 +25,8 @@ class CvesListView(ListView):
             cve_count = fn.COALESCE(cve_count, 0)
         query = self._full_query(cve_count, join_type, query_args) if not ids_only else self._id_query(join_type, query_args)
         query = apply_filters(query, args, [filter_types.CVE_BUSINESS_RISK, filter_types.CVE_CVSS, filter_types.CVE_IMPACT, filter_types.CVE_PUBLIC_DATE,
-                                            filter_types.CVE_RULE_PRESENCE, filter_types.CVE_SHOW_ALL, filter_types.CVE_STATUS])
+                                            filter_types.CVE_RULE_PRESENCE, filter_types.CVE_SHOW_ALL, filter_types.CVE_STATUS,
+                                            filter_types.CVE_RULE_PRESENCE_OLD])
         query = query.dicts()
         sortable_columns = {
             "systems_affected": SQL('systems_affected'),
@@ -116,6 +118,7 @@ class GetCves(GetRequest):
                      {'arg_name': 'impact', 'convert_func': parse_int_list},
                      {'arg_name': 'business_risk_id', 'convert_func': parse_int_list},
                      {'arg_name': 'status_id', 'convert_func': parse_int_list},
+                     {'arg_name': 'rule_presence', 'convert_func': unique_bool_list},
                      {'arg_name': 'security_rule', 'convert_func': None}]
         args = cls._parse_arguments(kwargs, args_desc)
         list_arguments = cls._parse_list_arguments(kwargs)

--- a/tests/manager_tests/schemas.py
+++ b/tests/manager_tests/schemas.py
@@ -138,8 +138,9 @@ _vulnerabilities_meta = {
     "impact": Or(None, str),
     "business_risk_id": Or(None, str),
     "status_id": Or(None, str),
-    "security_rule": Or(None, bool),
-    "system_count": Or(None, int)
+    "system_count": Or(None, int),
+    "rule_presence": Or(None, str),
+    "security_rule": Or(None, bool)
 }
 _vulnerabilities_meta.update(_meta)
 
@@ -183,6 +184,7 @@ _system_cves_meta = {
     "opt_out": bool,
     "business_risk_id": Or(None, str),
     "security_rule": Or(None, bool),
+    "rule_presence": Or(None, str)
 }
 _system_cves_meta.update(_meta)
 
@@ -199,7 +201,9 @@ _system_details = {
 _affected_systems_meta = {
     "status_id": Or(None, str),
     "security_rule": Or(None, str, bool),
-    "uuid": Or(None, str)
+    "uuid": Or(None, str),
+    "rule_presence": Or(None, str),
+    "rule_key": Or(None, str)
 }
 _affected_systems_meta.update(_meta)
 

--- a/tests/manager_tests/test_cve_handler.py
+++ b/tests/manager_tests/test_cve_handler.py
@@ -53,15 +53,37 @@ class TestCveHandler(FlaskTestCase):
         response = self.vfetch('cves/CVE-2017-8/affected_systems/ids?security_rule=false').check_response()
         assert len(response.body.data) == 1
 
+        response = self.vfetch('cves/CVE-2017-8/affected_systems?rule_presence=true').check_response()
+        assert len(response.body.data) == 2
+        response = self.vfetch('cves/CVE-2017-8/affected_systems/ids?rule_presence=true').check_response()
+        assert len(response.body.data) == 2
+        response = self.vfetch('cves/CVE-2017-8/affected_systems?rule_presence=false').check_response()
+        assert len(response.body.data) == 1
+        response = self.vfetch('cves/CVE-2017-8/affected_systems/ids?rule_presence=false').check_response()
+        assert len(response.body.data) == 1
+
         response = self.vfetch(
                         'cves/CVE-2017-8/affected_systems?security_rule=CVE_2018_12130_cpu_kernel|CVE_2018_12130_CPU_KERNEL_BAD_MICROCODE').check_response()
+        assert len(response.body.data) == 1
+
+        response = self.vfetch(
+                        'cves/CVE-2017-8/affected_systems?rule_key=CVE_2018_12130_cpu_kernel|CVE_2018_12130_CPU_KERNEL_BAD_MICROCODE').check_response()
         assert len(response.body.data) == 1
 
         response = (self.vfetch('cves/CVE-2017-8/affected_systems/ids?security_rule=CVE_2018_12130_cpu_kernel|CVE_2018_12130_CPU_KERNEL_BAD_MICROCODE')
                     .check_response())
         assert len(response.body.data) == 1
 
+        response = (self.vfetch('cves/CVE-2017-8/affected_systems/ids?rule_key=CVE_2018_12130_cpu_kernel|CVE_2018_12130_CPU_KERNEL_BAD_MICROCODE')
+                    .check_response())
+        assert len(response.body.data) == 1
+
         path = 'cves/CVE-2017-8/affected_systems?security_rule=CVE_2018_12130_cpu_kernel|' \
+               'CVE_2018_12130_CPU_KERNEL_BAD_MICROCODE,CVE_2018_12130_cpu_kernel|CVE_2018_12130_CPU_KERNEL_NEED_UPDATE'
+        response = self.vfetch(path).check_response()
+        assert len(response.body.data) == 2
+
+        path = 'cves/CVE-2017-8/affected_systems?rule_key=CVE_2018_12130_cpu_kernel|' \
                'CVE_2018_12130_CPU_KERNEL_BAD_MICROCODE,CVE_2018_12130_cpu_kernel|CVE_2018_12130_CPU_KERNEL_NEED_UPDATE'
         response = self.vfetch(path).check_response()
         assert len(response.body.data) == 2
@@ -86,3 +108,19 @@ class TestCveHandler(FlaskTestCase):
         response = self.vfetch('cves/CVE-2018-1/affected_systems?sort=inventory_id').check_response()
         assert response.body.data[0].attributes.reporter == 3  # on INV-5 it's reported by VMaaS and rule
         assert response.body.data[1].attributes.reporter == 2  # on INV-7 it's reported by rules
+
+    def test_cves_affected_systems_rule_presence_bools(self):
+        """Test that multiple different bools, must have
+           the same behaviour as not specified parameter"""
+        response_bools = self.vfetch('cves/CVE-2017-8/affected_systems?rule_presence=false,true').check_response()
+        response_all = self.vfetch('cves/CVE-2017-8/affected_systems').check_response()
+
+        assert response_bools.body.meta.total_items == response_all.body.meta.total_items
+
+    def test_cves_affected_systems_rule_presence_multiple_same_bools(self):
+        """Test with multiple same bools"""
+        response_multiple = self.vfetch('cves/CVE-2017-8/affected_systems?rule_presence=true,true,true,true').check_response()
+        response_single = self.vfetch('cves/CVE-2017-8/affected_systems?rule_presence=true').check_response()
+
+        assert response_multiple.body.meta.total_items == response_single.body.meta.total_items
+        assert response_multiple.body.meta.rule_presence == 'True'

--- a/tests/manager_tests/test_system_handler.py
+++ b/tests/manager_tests/test_system_handler.py
@@ -225,6 +225,15 @@ class TestSystemHandler(FlaskTestCase):
         response = self.vfetch('systems/INV-5/cves').check_response()
         assert len(response.body.data) == cves_with_rule + cves_without_rule
 
+        response = self.vfetch('systems/INV-5/cves?rule_presence=true').check_response()
+        cves_with_rule = len(response.body.data)
+        assert cves_with_rule == 5
+        response = self.vfetch('systems/INV-5/cves?rule_presence=false').check_response()
+        cves_without_rule = len(response.body.data)
+        assert cves_without_rule == 2
+        response = self.vfetch('systems/INV-5/cves').check_response()
+        assert len(response.body.data) == cves_with_rule + cves_without_rule
+
     def test_systems_stale_filter(self):
         response = self.vfetch('systems?stale=true')
         response2 = self.vfetch('systems/ids?stale=true')
@@ -263,3 +272,23 @@ class TestSystemHandler(FlaskTestCase):
 
         response = self.vfetch('systems/INV-5/cves?filter=CVE-2018-1').check_response()
         assert response.body.data[0].attributes.reporter == 3  # reported by both VMaaS and rules
+
+    def test_system_cves_rule_filter_multiple_bools(self):
+        """Test that multiple different bools, must have
+           the same behaviour as not specified parameter"""
+        response_bools = self.vfetch('systems/INV-3/cves?rule_presence=true,false').check_response()
+        response_all = self.vfetch('systems/INV-3/cves').check_response()
+
+        assert response_bools.body.meta.total_items == response_all.body.meta.total_items
+
+    def test_system_cves_rule_filter_multiple_same_bools(self):
+        """Test with multiple same bools"""
+        response_multiple = self.vfetch('systems/INV-3/cves?rule_presence=true,true,true,true').check_response()
+        response_single = self.vfetch('systems/INV-3/cves?rule_presence=true').check_response()
+
+        assert response_multiple.body.meta.total_items == response_single.body.meta.total_items
+        assert response_multiple.body.meta.rule_presence == 'True'
+
+    def test_system_cves_rule_filter_multiple_wrong(self):
+        """Test for invalid boolean value in multiple booleans"""
+        self.vfetch('systems/INV-3/cves?rule_presence=true,thisisnotbool').check_response(status_code=400)

--- a/tests/manager_tests/test_vulnerabilities_handler.py
+++ b/tests/manager_tests/test_vulnerabilities_handler.py
@@ -138,6 +138,13 @@ class TestVulnerabilitiesHandler(FlaskTestCase):
         response2 = self.vfetch('vulnerabilities/cves/ids?security_rule=false').check_response()
         assert len(response.body.data) == len(response2.body.data) == 6
 
+        response = self.vfetch('vulnerabilities/cves?rule_presence=true').check_response()
+        response2 = self.vfetch('vulnerabilities/cves/ids?rule_presence=true').check_response()
+        assert len(response.body.data) == len(response2.body.data) == 7  # 7 CVEs are associated with active rules
+        response = self.vfetch('vulnerabilities/cves?rule_presence=false').check_response()
+        response2 = self.vfetch('vulnerabilities/cves/ids?rule_presence=false').check_response()
+        assert len(response.body.data) == len(response2.body.data) == 6
+
     def test_na_cvss_filter(self):
         """Test CVSS filter for n/a cvss ratings."""
         response = self.vfetch('vulnerabilities/cves?cvss_from=-1&cvss_to=-1').check_response()
@@ -159,3 +166,23 @@ class TestVulnerabilitiesHandler(FlaskTestCase):
                 assert float(rec.attributes.cvss3_score) <= 5.9
             elif rec.attributes.cvss2_score:
                 assert float(rec.attributes.cvss2_score) <= 5.9
+
+    def test_vulnerabilities_rule_filter_multiple_bools(self):
+        """Test that multiple different bools, must have
+           the same behaviour as not specified parameter"""
+        response_bools = self.vfetch('vulnerabilities/cves?rule_presence=true,false').check_response()
+        response_all = self.vfetch('vulnerabilities/cves?').check_response()
+
+        assert response_bools.body.meta.total_items == response_all.body.meta.total_items
+
+    def test_vulnerabilities_rule_filter_multiple_same_bools(self):
+        """Test with multiple same bools"""
+        response_multiple = self.vfetch('vulnerabilities/cves?rule_presence=true,true,true,true').check_response()
+        response_single = self.vfetch('vulnerabilities/cves?rule_presence=true').check_response()
+
+        assert response_multiple.body.meta.total_items == response_single.body.meta.total_items
+        assert response_multiple.body.meta.rule_presence == 'True'
+
+    def test_vulnerabilities_rule_filter_multiple_wrong(self):
+        """Test for invalid boolean value in multiple booleans"""
+        self.vfetch('vulnerabilities/cves?rule_presence=true,thisisnotbool').check_response(status_code=400)


### PR DESCRIPTION
Because the UI wants to use checkboxes for filtering rules and we are using one parameter for multiple operations, we need to split it in two parameters.

- `security_rule` parameter is only used for filtering rules errkeys (data type: array of strings (errkeys))
- `rule_presence` parameter is only used for rule presence boolean (data type: array of booleans (support for checkboxes when request come as true,false; true; etc...)