### PR TITLE
feat(manager): add 'updated' sort parameter

### DIFF
--- a/manager.spec.yaml
+++ b/manager.spec.yaml
@@ -2191,6 +2191,11 @@ components:
               type: boolean
               description: System stale status.
               example: true
+            updated:
+              type: string
+              description: Date of the lastest upload of archive taken from Inventory syndicated data.
+              example: '2018-09-22T16:00:00+00:00'
+              nullable: true
             tags:
               type: array
               items:
@@ -2285,6 +2290,11 @@ components:
                       stale_warning_timestamp:
                         type: string
                         description: Date when stale system becomes hidden in the application.
+                        example: '2018-09-22T16:00:00+00:00'
+                        nullable: true
+                      updated:
+                        type: string
+                        description: Date of the lastest upload of archive taken from Inventory syndicated data.
                         example: '2018-09-22T16:00:00+00:00'
                         nullable: true
                       tags:

--- a/manager/cve_handler.py
+++ b/manager/cve_handler.py
@@ -46,9 +46,10 @@ class AffectedSystemsView(ListView):
             'last_upload': SystemPlatform.last_upload,
             'rules_evaluation': SystemPlatform.advisor_evaluated,
             'status_id': Status.id,
-            'status': Status.id
+            'status': Status.id,
+            'updated': InventoryHosts.updated if CYNDI_ENABLED else SystemPlatform.last_upload
         }
-        default_sort_columns = ['-last_upload', 'id']
+        default_sort_columns = ['-updated', 'id']
         filterable_columns = {
             'display_name': SystemPlatform.display_name
         }

--- a/manager/system_handler.py
+++ b/manager/system_handler.py
@@ -140,9 +140,10 @@ class SystemView(ListView):
             'last_evaluation': SystemPlatform.last_evaluation,
             'last_upload': SystemPlatform.last_upload,
             'display_name': SystemPlatform.display_name,
-            'rules_evaluation': SystemPlatform.advisor_evaluated
+            'rules_evaluation': SystemPlatform.advisor_evaluated,
+            'updated': InventoryHosts.updated if CYNDI_ENABLED else SystemPlatform.last_upload
         }
-        default_sort_columns = ['-last_upload', 'id']
+        default_sort_columns = ['-updated', 'id']
         filterable_columns = {
             'display_name': SystemPlatform.display_name
         }
@@ -162,6 +163,7 @@ class SystemView(ListView):
                        SystemPlatform.stale_warning_timestamp]
         if CYNDI_ENABLED:
             selectables.append(InventoryHosts.tags)
+            selectables.append(InventoryHosts.updated)
 
         return (
             SystemPlatform
@@ -220,6 +222,7 @@ class GetSystems(GetRequest):
                 system['last_upload'] = system['last_upload'].isoformat() if system['last_upload'] else None
                 system['stale_timestamp'] = system['stale_timestamp'].isoformat() if system['stale_timestamp'] else None
                 system['stale_warning_timestamp'] = system['stale_warning_timestamp'].isoformat() if system['stale_warning_timestamp'] else None
+                system['updated'] = system['updated'] if CYNDI_ENABLED else system['last_upload']
                 system['tags'] = system['tags'] if CYNDI_ENABLED and system['tags'] is not None else []
                 record['attributes'] = system
                 if system['opt_out']:
@@ -354,6 +357,7 @@ class GetSystemDetails(GetRequest):
                            SystemPlatform.stale]
             if CYNDI_ENABLED:
                 selectables.append(InventoryHosts.tags)
+                selectables.append(InventoryHosts.updated)
 
             query = (SystemPlatform.select(*selectables)
                      .join(RHAccount, on=(SystemPlatform.rh_account_id == RHAccount.id))
@@ -365,7 +369,8 @@ class GetSystemDetails(GetRequest):
             raise ApplicationException('inventory_id must exist and inventory_id must be visible to user', 404)
         return {'data': {'last_evaluation': system['last_evaluation'], 'rules_evaluation': system['advisor_evaluated'], 'opt_out': system['opt_out'],
                          'last_upload': system['last_upload'], 'stale': system['stale'],
-                         'tags': system['tags'] if CYNDI_ENABLED and system['tags'] is not None else []}}
+                         'tags': system['tags'] if CYNDI_ENABLED and system['tags'] is not None else [],
+                         'updated': system['updated'] if CYNDI_ENABLED else system['last_upload']}}
 
     @staticmethod
     def _cyndi_query(query):

--- a/tests/manager_tests/schemas.py
+++ b/tests/manager_tests/schemas.py
@@ -66,7 +66,7 @@ _system = {
     "attributes": {"inventory_id": str, "rules_evaluation": Or(str, None),
                    "cve_count": Or(None, int), "display_name": Or(None, str), "last_evaluation": Or(str, None), "opt_out": bool,
                    "last_upload": Or(None, str), "stale_timestamp": Or(None, str), "stale_warning_timestamp": Or(None, str),
-                   "tags": Or([_tags], [])},
+                   "tags": Or([_tags], []), "updated": Or(None, str)},
 }
 
 _insights_rule = {
@@ -205,7 +205,8 @@ _system_details = {
         'opt_out': bool,
         'stale': bool,
         'last_upload': Or(None, str),
-        'tags': Or([_tags], [])
+        'tags': Or([_tags], []),
+        'updated': Or(None, str)
     }
 }
 


### PR DESCRIPTION
'updated' sort parameter behaves similarly like 'last_upload', but the information about 'last_upload' is taken from Cyndi.
When Cyndi is disabled, it behaves just like 'last_upload'.