### PR TITLE
fix(manager): casting to TEXT on inventory.hosts may be very slow

### DIFF
--- a/manager/base.py
+++ b/manager/base.py
@@ -556,5 +556,5 @@ def parse_tags(tags_list):
 def cyndi_query(query):
     """Function adds join on cyndi table, based if cyndi is enabled."""
     if CYNDI_ENABLED:
-        query = query.join(InventoryHosts, JOIN.INNER, on=(SystemPlatform.inventory_id == InventoryHosts.id.cast("TEXT")))
+        query = query.join(InventoryHosts, JOIN.INNER, on=(SystemPlatform.inventory_id.cast("UUID") == InventoryHosts.id))
     return query


### PR DESCRIPTION
probably because whole inventory.hosts table needs to be casted sequentialy when selecting single system