### PR TITLE
feat(manager): move current admin calls to path accessible using Turnpike

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,6 +59,7 @@ ADD entrypoint.sh                          /engine/
 ADD /listener/*.py                         /engine/listener/
 ADD /evaluator/*.py                        /engine/evaluator/
 ADD manager.spec.yaml                      /engine/
+ADD manager.admin.spec.yaml                /engine/
 ADD /manager/*.py                          /engine/manager/
 ADD /database/*.py                         /engine/database/
 ADD /database/upgrade/*.py                 /engine/database/upgrade/

--- a/manager.admin.spec.yaml
+++ b/manager.admin.spec.yaml
@@ -1,0 +1,203 @@
+openapi: "3.0.0"
+
+info:
+  title: Vulnerability Engine Manager Admin
+  version: {{ app_version }}
+
+paths:
+  /version:
+    get:
+      summary: Application version
+      description: Get application version.
+      operationId: manager.version_handler.GetVersion.get
+      x-methodName: getVersion
+      responses:
+        200:
+          description: Application version.
+          content:
+            application/vnd.api+json:
+              schema:
+                $ref: '#/components/schemas/VersionOut'
+  
+  /refresh/accounts/{account_id}:
+    put:
+      summary: Refresh cached counts for given account ID.
+      description: Refresh cached counts for given account ID. Admin interface, available only to internal users.
+      operationId: manager.refresh_handler.RefreshAccount.put
+      x-methodName: refreshAccount
+      security:
+        - ApiKeyAuthAdmin: []
+      responses:
+        200:
+          description: Cached counts for given account successfully updated.
+        404:
+          description: Account was not found.
+          content:
+            application/vnd.api+json:
+              schema:
+                $ref: '#/components/schemas/Errors'
+        503:
+          description: Service is running in read-only mode.
+          content:
+            application/vnd.api+json:
+              schema:
+                $ref: '#/components/schemas/Errors'
+      parameters: 
+        - $ref: '#/components/parameters/account_id'
+
+  /refresh/accounts/{account_id}/cves/{cve_id}:
+    put:
+      summary: Refresh cached counts for given account ID and CVE.
+      description: Refresh cached counts for given account ID and CVE. Admin interface, available only to admin users.
+      operationId: manager.refresh_handler.RefreshAccountCve.put
+      x-methodName: refreshAccountCve
+      security:
+        - ApiKeyAuthAdmin: []
+      responses:
+        200:
+          description: Cached counts for given account and CVE successfully updated.
+        404:
+          description: Account or CVE was not found.
+          content:
+            application/vnd.api+json:
+              schema:
+                $ref: '#/components/schemas/Errors'
+        503:
+          description: Service is running in read-only mode.
+          content:
+            application/vnd.api+json:
+              schema:
+                $ref: '#/components/schemas/Errors'
+      parameters: 
+        - $ref: '#/components/parameters/account_id'
+        - $ref: '#/components/parameters/cve_id'
+
+  /refresh/cves/{cve_id}:
+    put:
+      summary: Refresh cached counts for given CVE.
+      description: Refresh cached counts for given CVE. Admin interface, available only to admin users.
+      operationId: manager.refresh_handler.RefreshCve.put
+      x-methodName: refreshCve
+      security:
+        - ApiKeyAuthAdmin: []
+      responses:
+        200:
+          description: Cached counts for given CVE successfully updated.
+        404:
+          description: CVE was not found.
+          content:
+            application/vnd.api+json:
+              schema:
+                $ref: '#/components/schemas/Errors'
+        503:
+          description: Service is running in read-only mode.
+          content:
+            application/vnd.api+json:
+              schema:
+                $ref: '#/components/schemas/Errors'
+      parameters: 
+        - $ref: '#/components/parameters/cve_id'
+
+  /refresh/systems/{inventory_id}:
+    put:
+      summary: Refresh cached counts for given inventory ID.
+      description: Refresh cached counts for given inventory ID. Admin interface, available only to admin users.
+      operationId: manager.refresh_handler.RefreshSystem.put
+      x-methodName: refreshSystem
+      security:
+        - ApiKeyAuthAdmin: []
+      responses:
+        200:
+          description: Cached counts for given system successfully updated.
+        404:
+          description: System was not found.
+          content:
+            application/vnd.api+json:
+              schema:
+                $ref: '#/components/schemas/Errors'
+        503:
+          description: Service is running in read-only mode.
+          content:
+            application/vnd.api+json:
+              schema:
+                $ref: '#/components/schemas/Errors'
+      parameters: 
+        - $ref: '#/components/parameters/inventory_id'
+
+components:
+  parameters:
+    inventory_id:
+      in: path
+      name: inventory_id
+      description: Inventory ID.
+      required: true
+      schema:
+        type: string
+      example: INV-ID-0000-1234
+
+    cve_id:
+      in: path
+      name: cve_id
+      description: CVE id.
+      required: true
+      schema:
+        type: string
+      example: CVE-2016-0800
+
+    account_id:
+      in: path
+      name: account_id
+      description: Account ID of user.
+      required: true
+      schema:
+        type: string
+      example: '123456'
+
+  securitySchemes:
+    ApiKeyAuthAdmin:
+      type: apiKey
+      in: header
+      name: x-rh-identity
+      description: Identity header provided by Turnpike (for non-prod testing only).
+      x-apikeyInfoFunc: manager.base.auth_admin
+
+  schemas:
+    Errors:
+      type: object
+      properties:
+        errors:
+          type: array
+          items:
+            type: object
+            properties:
+              detail:
+                type: string
+                description: Error detail.
+                example: Record not found.
+              status:
+                type: string
+                description: String representation of HTTP status code.
+                example: 404
+            required:
+              - detail
+              - status
+          minItems: 1
+      required:
+        - errors
+
+    VersionOut:
+      type: object
+      properties:
+        application_version:
+          type: string
+          description: Version of application.
+          example: 0.1.2
+        database_version:
+          oneOf:
+            - type: string
+            - type: number
+          description: Version of database schema.
+          example: 1
+      required:
+        - application_version
+        - database_version

--- a/manager.spec.yaml
+++ b/manager.spec.yaml
@@ -765,123 +765,6 @@ paths:
             maxItems: 2
           example: true,false
 
-  /refresh/accounts/{account_id}:
-    put:
-      summary: Refresh cached counts for given account ID.
-      description: Refresh cached counts for given account ID. Admin interface, available only to internal users.
-      operationId: manager.refresh_handler.RefreshAccount.put
-      x-methodName: refreshAccount
-      security:
-        - ApiKeyAuthInternal: []
-        - BasicAuth: []
-      responses:
-        200:
-          description: Cached counts for given account successfully updated.
-        404:
-          description: Account was not found.
-          content:
-            application/vnd.api+json:
-              schema:
-                $ref: '#/components/schemas/Errors'
-        503:
-          description: Service is running in read-only mode.
-          content:
-            application/vnd.api+json:
-              schema:
-                $ref: '#/components/schemas/Errors'
-      parameters: 
-        - $ref: '#/components/parameters/account_id'
-      tags:
-        - internal
-
-  /refresh/accounts/{account_id}/cves/{cve_id}:
-    put:
-      summary: Refresh cached counts for given account ID and CVE.
-      description: Refresh cached counts for given account ID and CVE. Admin interface, available only to internal users.
-      operationId: manager.refresh_handler.RefreshAccountCve.put
-      x-methodName: refreshAccountCve
-      security:
-        - ApiKeyAuthInternal: []
-        - BasicAuth: []
-      responses:
-        200:
-          description: Cached counts for given account and CVE successfully updated.
-        404:
-          description: Account or CVE was not found.
-          content:
-            application/vnd.api+json:
-              schema:
-                $ref: '#/components/schemas/Errors'
-        503:
-          description: Service is running in read-only mode.
-          content:
-            application/vnd.api+json:
-              schema:
-                $ref: '#/components/schemas/Errors'
-      parameters: 
-        - $ref: '#/components/parameters/account_id'
-        - $ref: '#/components/parameters/cve_id'
-      tags:
-        - internal
-
-  /refresh/cves/{cve_id}:
-    put:
-      summary: Refresh cached counts for given CVE.
-      description: Refresh cached counts for given CVE. Admin interface, available only to internal users.
-      operationId: manager.refresh_handler.RefreshCve.put
-      x-methodName: refreshCve
-      security:
-        - ApiKeyAuthInternal: []
-        - BasicAuth: []
-      responses:
-        200:
-          description: Cached counts for given CVE successfully updated.
-        404:
-          description: CVE was not found.
-          content:
-            application/vnd.api+json:
-              schema:
-                $ref: '#/components/schemas/Errors'
-        503:
-          description: Service is running in read-only mode.
-          content:
-            application/vnd.api+json:
-              schema:
-                $ref: '#/components/schemas/Errors'
-      parameters: 
-        - $ref: '#/components/parameters/cve_id'
-      tags:
-        - internal
-
-  /refresh/systems/{inventory_id}:
-    put:
-      summary: Refresh cached counts for given inventory ID.
-      description: Refresh cached counts for given inventory ID. Admin interface, available only to internal users.
-      operationId: manager.refresh_handler.RefreshSystem.put
-      x-methodName: refreshSystem
-      security:
-        - ApiKeyAuthInternal: []
-        - BasicAuth: []
-      responses:
-        200:
-          description: Cached counts for given system successfully updated.
-        404:
-          description: System was not found.
-          content:
-            application/vnd.api+json:
-              schema:
-                $ref: '#/components/schemas/Errors'
-        503:
-          description: Service is running in read-only mode.
-          content:
-            application/vnd.api+json:
-              schema:
-                $ref: '#/components/schemas/Errors'
-      parameters: 
-        - $ref: '#/components/parameters/inventory_id'
-      tags:
-        - internal
-
 components:
   parameters:
     filter:
@@ -1133,13 +1016,6 @@ components:
       name: x-rh-identity
       description: Identity header provided by 3scale (for non-prod testing only).
       x-apikeyInfoFunc: manager.base.auth
-    
-    ApiKeyAuthInternal:
-      type: apiKey
-      in: header
-      name: x-rh-identity
-      description: Identity header provided by 3scale (for non-prod testing only).
-      x-apikeyInfoFunc: manager.base.auth_internal
 
   schemas:
     Errors:

--- a/manager/base.py
+++ b/manager/base.py
@@ -27,6 +27,7 @@ LOGGER = get_logger(__name__)
 DEFAULT_ROUTE = "%s/%s/%s" % (os.getenv('PATH_PREFIX', "/api"),
                               os.getenv('APP_NAME', "vulnerability"),
                               os.getenv('API_VERSION', "v1"))
+ADMIN_ROUTE = "/admin%s" % DEFAULT_ROUTE
 IDENTITY_HEADER = "x-rh-identity"
 DEFAULT_PAGE_SIZE = 20
 READ_ONLY_MODE = strtobool(os.environ.get('READ_ONLY_MODE', 'FALSE'))
@@ -48,6 +49,7 @@ LOGGER.info("Access URL: %s", DEFAULT_ROUTE)
 # Counter for all-the-get-calls, dealt with in BaseHandler
 REQUEST_COUNTS = Counter('ve_manager_invocations', 'Number of calls per handler', ['method', 'endpoint', 'source'])
 ACCOUNT_REQUESTS = Counter('ve_manager_account_invocations', 'Number of calls per account', ['account'])
+ADMIN_REQUESTS = Counter('ve_manager_admin_invocations', 'Number of calls on admin API')
 
 CYNDI_ENABLED = strtobool(os.getenv('CYNDI_ENABLED', 'TRUE'))
 
@@ -87,10 +89,6 @@ class ApplicationException(Exception):
 
 class MissingEntitlementException(Exception):
     """entitlement is missing"""
-
-
-class InternalOnlyException(Exception):
-    """function is available only for internal users"""
 
 
 class ReadOnlyModeException(Exception):
@@ -152,28 +150,20 @@ def auth(x_rh_identity, required_scopes=None):  # pylint: disable=unused-argumen
     return auth_common(identity, x_rh_identity) if identity is not None else None
 
 
-def auth_internal(x_rh_identity, required_scopes=None):  # pylint: disable=unused-argument
+def auth_admin(x_rh_identity, required_scopes=None):  # pylint: disable=unused-argument
     """
-    Parses account number from the x-rh-identity header and ensures account is internal
+    Parses user name from the x-rh-identity header
     """
     identity = get_identity(x_rh_identity)
-    if identity is not None:
-        if 'identity' not in identity or 'user' not in identity['identity'] or \
-                not identity['identity']['user'].get('is_internal', False):
-            raise InternalOnlyException
-    return auth_common(identity, x_rh_identity) if identity is not None else None
+    user = identity.get("identity", {}).get("associate", {}).get("email")
+    LOGGER.info("User '%s' accessed admin API.", user)
+    ADMIN_REQUESTS.inc()
+    return {"uid": user} if user else None
 
 
 def forbidden_missing_entitlement(exception):  # pylint: disable=unused-argument
     """Override default connexion 401 coming from auth() with 403"""
     return Response(response=json.dumps({'errors': [{'detail': 'insights entitlement is missing',
-                                                     'status': '403'}]}),
-                    status=403, mimetype='application/vnd.api+json')
-
-
-def forbidden_internal_only(exception):  # pylint: disable=unused-argument
-    """Override default connexion 401 coming from auth() with 403"""
-    return Response(response=json.dumps({'errors': [{'detail': 'api is available for internal users only',
                                                      'status': '403'}]}),
                     status=403, mimetype='application/vnd.api+json')
 

--- a/manager/main.py
+++ b/manager/main.py
@@ -16,8 +16,8 @@ from common.constants import APP_VERSION
 from common.logging import init_logging, get_logger
 from common.peewee_database import DB
 
-from .base import DEFAULT_ROUTE, forbidden_missing_entitlement, forbidden_internal_only, forbidden_rbac, \
-    MissingEntitlementException, InternalOnlyException, RbacException
+from .base import DEFAULT_ROUTE, forbidden_missing_entitlement, forbidden_rbac, \
+    MissingEntitlementException, RbacException, ADMIN_ROUTE
 
 LOGGER = get_logger(__name__)
 
@@ -32,8 +32,13 @@ def create_app():
                 strict_validation=True,
                 base_path=DEFAULT_ROUTE,
                 arguments={'app_version': APP_VERSION})
+    app.add_api('manager.admin.spec.yaml',
+                resolver=RestyResolver('api'),
+                validate_responses=True,
+                strict_validation=True,
+                base_path=ADMIN_ROUTE,
+                arguments={'app_version': APP_VERSION})
     app.add_error_handler(MissingEntitlementException, forbidden_missing_entitlement)
-    app.add_error_handler(InternalOnlyException, forbidden_internal_only)
     app.add_error_handler(RbacException, forbidden_rbac)
 
     @app.app.route('/metrics', methods=['GET'])

--- a/scripts/turnpike-mock
+++ b/scripts/turnpike-mock
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import json
+import base64
+import argparse
+
+
+DEFAULT_IDENTITY_FILE = os.environ['HOME'] + "/.turnpike-mock"
+DEFAULT_IDENTITY = """
+{
+  "identity": {
+    "associate": {
+      "Role": [
+        "vulnerability-admins"
+      ],
+      "email": "jschmoe@redhat.com",
+      "givenName": "Joseph",
+      "rhatUUID": "01234567-89ab-cdef-0123-456789abcdef",
+      "surname": "Schmoe"
+    },
+    "auth_type": "saml-auth",
+    "type": "Associate"
+  }
+}
+"""
+
+debug = False
+
+def load_identity(filepath):
+    if os.path.isfile(filepath):
+        if debug:
+            print('Attempting to load identity from %s' % filepath)
+        with open(filepath, 'r') as identity_file:
+            return json.load(identity_file)
+    if filepath == DEFAULT_IDENTITY_FILE:
+        if debug:
+            print('Using default identity, no identity file %s' % filepath)
+        return json.loads(DEFAULT_IDENTITY)
+    return None
+
+def save_identity(identity, filepath):
+    if debug:
+        print('Saving identity to file %s' % filepath)
+    with open(filepath, 'w') as identity_file:
+        identity_file.write(json.dumps(identity))
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument('-f', '--file', dest='input_file',
+                        default=DEFAULT_IDENTITY_FILE,
+                        help='file containing identity to use [default: %s]' % DEFAULT_IDENTITY_FILE)
+    parser.add_argument('-e', '--email',
+                        help='email to use in identity')
+    parser.add_argument('-d', '--debug', action='store_true',
+                        help='output additional information and details')
+    subparsers = parser.add_subparsers(help='commands', dest='command')
+    parser_save = subparsers.add_parser('save', help='save identity')
+    parser_save.add_argument('output_file', nargs='?',
+                             default=DEFAULT_IDENTITY_FILE,
+                             help='file to save [default: %s]' % DEFAULT_IDENTITY_FILE)
+
+    parser_print = subparsers.add_parser('print', help='print base64 encoded identity')
+
+    parser_curl = subparsers.add_parser('curl', help='issue curl command')
+
+    options, remaining = parser.parse_known_args()
+    if options.debug:
+        debug = True
+
+    identity = load_identity(options.input_file)
+    if not identity:
+        print('Unable to load identity from file %s' % options.input_file)
+        sys.exit(1)
+
+    if options.email:
+        identity['identity']['associate']['email'] = options.email
+
+    if options.command == 'save':
+        if remaining:
+            print('Unexpected args %s' % remaining)
+            sys.exit(1)
+        save_identity(identity, options.output_file)
+        print('Identity saved to file %s' % options.output_file)
+        sys.exit(0)
+
+    encoded_identity = base64.b64encode(json.dumps(identity).encode('utf-8')).decode('utf-8')
+
+    if options.command == 'print':
+        if remaining:
+            print('Unexpected args %s' % remaining)
+            sys.exit(1)        
+        print(encoded_identity)
+        sys.exit(0)
+
+    if options.command == 'curl':
+        if remaining:
+            args = remaining
+        else:
+            args = []
+        curl_command = 'curl'
+        curl_command += ' -H "x-rh-identity: %s"' % encoded_identity
+        curl_command += ' %s' % ' '.join('%s' % s if not True in [ c.isspace() or c in [';', '&'] for c in s ] else "'%s'" % s for s in args)
+
+        if debug:
+            print('Issuing the following curl command:')
+            print(curl_command)
+        os.system(curl_command)

--- a/tests/manager_tests/test_readonly.py
+++ b/tests/manager_tests/test_readonly.py
@@ -4,7 +4,7 @@
 Manager read only mode tests.
 """
 from manager import base
-from .vuln_testcase import FlaskTestCase
+from .vuln_testcase import FlaskTestCase, ADMIN_URL_BASE
 
 CSV_EXPORT_ENDPOINTS = ('cves/CVE-2016-1/affected_systems', 'systems',
                         'systems/00000000-0000-0000-0000-000000000004/cves', 'vulnerabilities/cves')
@@ -24,10 +24,10 @@ class TestManager(FlaskTestCase):
 
     def test_refresh(self, monkeypatch):
         monkeypatch.setattr(base, 'READ_ONLY_MODE', 1)
-        response = self.vfetch("refresh/accounts/0", internal_user=True, method="PUT")
+        response = self.vfetch("refresh/accounts/0", turnpike=True, url_base=ADMIN_URL_BASE, method="PUT")
         assert response.status_code == 503
 
     def test_delete(self, monkeypatch):
         monkeypatch.setattr(base, 'READ_ONLY_MODE', 1)
-        response = self.vfetch("systems/00000000-0000-0000-0000-000000000004", internal_user=True, method="DELETE")
+        response = self.vfetch("systems/00000000-0000-0000-0000-000000000004", method="DELETE")
         assert response.status_code == 503

--- a/tests/manager_tests/test_refresh_handler.py
+++ b/tests/manager_tests/test_refresh_handler.py
@@ -5,7 +5,7 @@ import pytest
 
 from manager.base import ApplicationException
 from manager.refresh_handler import Refresh
-from .vuln_testcase import FlaskTestCase
+from .vuln_testcase import FlaskTestCase, ADMIN_URL_BASE
 
 
 class TestRefreshHandler(FlaskTestCase):
@@ -26,23 +26,23 @@ class TestRefreshHandler(FlaskTestCase):
         assert exc.value.status_code == 400
 
     def test_refresh_account(self):
-        self.vfetch('refresh/accounts/0', method='PUT').check_response(403)
-        self.vfetch('refresh/accounts/INVALID', internal_user=True, method='PUT').check_response(404)
-        self.vfetch('refresh/accounts/0', internal_user=True, method='PUT').check_response()
+        self.vfetch('refresh/accounts/0', method='PUT', url_base=ADMIN_URL_BASE).check_response(401)
+        self.vfetch('refresh/accounts/INVALID', turnpike=True, method='PUT', url_base=ADMIN_URL_BASE).check_response(404)
+        self.vfetch('refresh/accounts/0', turnpike=True, method='PUT', url_base=ADMIN_URL_BASE).check_response()
 
     def test_refresh_account_cve(self):
-        self.vfetch('refresh/accounts/0/cves/CVE-2014-1', method='PUT').check_response(403)
-        self.vfetch('refresh/accounts/INVALID/cves/INVALID', internal_user=True, method='PUT').check_response(404)
-        self.vfetch('refresh/accounts/INVALID/cves/CVE-2014-1', internal_user=True, method='PUT').check_response(404)
-        self.vfetch('refresh/accounts/0/cves/INVALID', internal_user=True, method='PUT').check_response(404)
-        self.vfetch('refresh/accounts/0/cves/CVE-2014-1', internal_user=True, method='PUT').check_response()
+        self.vfetch('refresh/accounts/0/cves/CVE-2014-1', method='PUT', url_base=ADMIN_URL_BASE).check_response(401)
+        self.vfetch('refresh/accounts/INVALID/cves/INVALID', turnpike=True, method='PUT', url_base=ADMIN_URL_BASE).check_response(404)
+        self.vfetch('refresh/accounts/INVALID/cves/CVE-2014-1', turnpike=True, method='PUT', url_base=ADMIN_URL_BASE).check_response(404)
+        self.vfetch('refresh/accounts/0/cves/INVALID', turnpike=True, method='PUT', url_base=ADMIN_URL_BASE).check_response(404)
+        self.vfetch('refresh/accounts/0/cves/CVE-2014-1', turnpike=True, method='PUT', url_base=ADMIN_URL_BASE).check_response()
 
     def test_refresh_cve(self):
-        self.vfetch('refresh/cves/CVE-2014-1', method='PUT').check_response(403)
-        self.vfetch('refresh/cves/INVALID', internal_user=True, method='PUT').check_response(404)
-        self.vfetch('refresh/cves/CVE-2014-1', internal_user=True, method='PUT').check_response()
+        self.vfetch('refresh/cves/CVE-2014-1', method='PUT', url_base=ADMIN_URL_BASE).check_response(401)
+        self.vfetch('refresh/cves/INVALID', turnpike=True, method='PUT', url_base=ADMIN_URL_BASE).check_response(404)
+        self.vfetch('refresh/cves/CVE-2014-1', turnpike=True, method='PUT', url_base=ADMIN_URL_BASE).check_response()
 
     def test_refresh_system(self):
-        self.vfetch('refresh/systems/00000000-0000-0000-0000-000000000002', method='PUT').check_response(403)
-        self.vfetch('refresh/systems/11111111-1111-1111-1111-000000000001', internal_user=True, method='PUT').check_response(404)
-        self.vfetch('refresh/systems/00000000-0000-0000-0000-000000000002', internal_user=True, method='PUT').check_response()
+        self.vfetch('refresh/systems/00000000-0000-0000-0000-000000000002', method='PUT', url_base=ADMIN_URL_BASE).check_response(401)
+        self.vfetch('refresh/systems/11111111-1111-1111-1111-000000000001', turnpike=True, method='PUT', url_base=ADMIN_URL_BASE).check_response(404)
+        self.vfetch('refresh/systems/00000000-0000-0000-0000-000000000002', turnpike=True, method='PUT', url_base=ADMIN_URL_BASE).check_response()

--- a/tests/manager_tests/vuln_testcase.py
+++ b/tests/manager_tests/vuln_testcase.py
@@ -13,6 +13,7 @@ from manager import main
 from .schemas import SCHEMA_MAP
 
 URL_BASE = "/api/vulnerability/v1"
+ADMIN_URL_BASE = "/admin/api/vulnerability/v1"
 
 IDENTITY = {
     "identity": {
@@ -33,31 +34,28 @@ IDENTITY = {
     "entitlements": {"insights": {"is_entitled": True}},
 }
 
-INTERNAL_IDENTITY = {
+TURNPIKE_IDENTITY = {
     "identity": {
-        "account_number": "0",
-        "type": "User",
-        "user": {
-            "username": "jdoe@acme.com",
-            "email": "jdoe@acme.com",
-            "first_name": "john",
-            "last_name": "doe",
-            "is_active": True,
-            "is_org_admin": False,
-            "is_internal": True,
-            "locale": "en_US",
+        "associate": {
+            "Role": [
+                "vulnerability-admins"
+            ],
+            "email": "jschmoe@redhat.com",
+            "givenName": "Joseph",
+            "rhatUUID": "01234567-89ab-cdef-0123-456789abcdef",
+            "surname": "Schmoe"
         },
-        "internal": {"org_id": 3_340_851, "auth_type": "basic-auth", "auth_time": 6300},
-    },
-    "entitlements": {"insights": {"is_entitled": True}},
+        "auth_type": "saml-auth",
+        "type": "Associate"
+    }
 }
 
 RH_IDENTITY_HEADER = {
     "x-rh-identity": base64.b64encode(json.dumps(IDENTITY).encode("utf-8"))
 }
 
-RH_INTERNAL_IDENTITY_HEADER = {
-    "x-rh-identity": base64.b64encode(json.dumps(INTERNAL_IDENTITY).encode("utf-8"))
+RH_TURNPIKE_IDENTITY_HEADER = {
+    "x-rh-identity": base64.b64encode(json.dumps(TURNPIKE_IDENTITY).encode("utf-8"))
 }
 
 
@@ -75,12 +73,12 @@ class FlaskTestCase:
         connexion_app = main.create_app()
         return connexion_app.app
 
-    def vfetch(self, path, internal_user=False, **kwargs):
+    def vfetch(self, path, turnpike=False, url_base=URL_BASE, **kwargs):
         """Fetch method for vulnerability API."""
-        path = "{}/{}".format(URL_BASE, path.lstrip("/"))
+        path = "{}/{}".format(url_base, path.lstrip("/"))
         headers = kwargs.get("headers") or {}
-        if internal_user:
-            headers.update(RH_INTERNAL_IDENTITY_HEADER)
+        if turnpike:
+            headers.update(RH_TURNPIKE_IDENTITY_HEADER)
         else:
             headers.update(RH_IDENTITY_HEADER)
         kwargs["headers"] = headers


### PR DESCRIPTION
- preparation for Turnpike integration
- added turnpike-mock wrapper usable same as 3scale-mock
- no authorization here, when request hits API, we expect Turnpike validated that user is in 'vulnerability-admins' group
- /admin/api/vulnerability/ is not exposed in 3scale