### PR TITLE
fix(manager-admin): split admin functionality to separate container

### DIFF
--- a/docker-compose.devel.yml
+++ b/docker-compose.devel.yml
@@ -43,6 +43,15 @@ services:
       - label=disable
     working_dir: /git
     command: ["sleep", "infinity"]
+  
+  ve_manager_admin:
+    volumes:
+      - .:/git
+      - ./database:/git/database
+    security_opt:
+      - label=disable
+    working_dir: /git
+    command: ["sleep", "infinity"]
 
   ve_vmaas_sync:
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,6 +94,25 @@ services:
     depends_on:
       - ve_database
       - platform_mock
+  
+  ve_manager_admin:
+    command: /engine/entrypoint.sh manager-admin
+    container_name: vulnerability-engine-manager-admin
+    build:
+      context: ./
+      dockerfile: ./Dockerfile
+      args:
+        PIPENV_CHECK: "${PIPENV_CHECK:-1}"
+    image: vulnerability-engine-app:latest
+    restart: unless-stopped
+    env_file:
+      - ./conf/common.env
+      - ./conf/manager.env
+    ports:
+      - 8400:8000
+    depends_on:
+      - ve_database
+      - platform_mock
 
   platform_mock:
     container_name: platform-mock

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,6 +11,8 @@ if [[ ! -z $1 ]]; then
         exec python3 -m vmaas_sync.vmaas_sync
     elif [[ "$1" == "manager" ]]; then
         exec gunicorn -c manager/gunicorn_conf.py -w ${GUNICORN_WORKERS:-4} --bind=0.0.0.0:8000 --timeout=60 manager.main
+    elif [[ "$1" == "manager-admin" ]]; then
+        exec gunicorn -c manager/gunicorn_conf.py -w ${GUNICORN_WORKERS:-4} --bind=0.0.0.0:8000 --timeout=60 manager.admin
     elif [[ "$1" == "advisor-listener" ]]; then
         exec python3 -m advisor_listener.advisor_listener
     elif [[ "$1" == "taskomatic" ]]; then

--- a/manager/admin.py
+++ b/manager/admin.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+"""
+vulnerability-manager-admin
+"""
+import os
+
+from common.logging import init_logging, get_logger
+
+from .main import create_app
+
+LOGGER = get_logger(__name__)
+
+
+init_logging(num_servers=int(os.getenv("GUNICORN_WORKERS", "4")))
+#  gunicorn expects an object called 'application' hence the pylint disable
+application = create_app('manager.admin.spec.yaml')  # pylint: disable=invalid-name
+
+if __name__ == '__main__':
+    application.run(host='0.0.0.0', port=8000)

--- a/manager/base.py
+++ b/manager/base.py
@@ -27,7 +27,6 @@ LOGGER = get_logger(__name__)
 DEFAULT_ROUTE = "%s/%s/%s" % (os.getenv('PATH_PREFIX', "/api"),
                               os.getenv('APP_NAME', "vulnerability"),
                               os.getenv('API_VERSION', "v1"))
-ADMIN_ROUTE = "/admin%s" % DEFAULT_ROUTE
 IDENTITY_HEADER = "x-rh-identity"
 DEFAULT_PAGE_SIZE = 20
 READ_ONLY_MODE = strtobool(os.environ.get('READ_ONLY_MODE', 'FALSE'))

--- a/manager/main.py
+++ b/manager/main.py
@@ -17,26 +17,20 @@ from common.logging import init_logging, get_logger
 from common.peewee_database import DB
 
 from .base import DEFAULT_ROUTE, forbidden_missing_entitlement, forbidden_rbac, \
-    MissingEntitlementException, RbacException, ADMIN_ROUTE
+    MissingEntitlementException, RbacException
 
 LOGGER = get_logger(__name__)
 
 
-def create_app():
+def create_app(spec_file):
     """Creates an aplication object which is then served by tornado"""
     app = connexion.App('Vulnerability Engine Manager', options={'swagger_ui': True})
     app.app.url_map.strict_slashes = False
-    app.add_api('manager.spec.yaml',
+    app.add_api(spec_file,
                 resolver=RestyResolver('api'),
                 validate_responses=True,
                 strict_validation=True,
                 base_path=DEFAULT_ROUTE,
-                arguments={'app_version': APP_VERSION})
-    app.add_api('manager.admin.spec.yaml',
-                resolver=RestyResolver('api'),
-                validate_responses=True,
-                strict_validation=True,
-                base_path=ADMIN_ROUTE,
                 arguments={'app_version': APP_VERSION})
     app.add_error_handler(MissingEntitlementException, forbidden_missing_entitlement)
     app.add_error_handler(RbacException, forbidden_rbac)
@@ -86,7 +80,7 @@ def create_app():
 
 init_logging(num_servers=int(os.getenv("GUNICORN_WORKERS", "4")))
 #  gunicorn expects an object called 'application' hence the pylint disable
-application = create_app()  # pylint: disable=invalid-name
+application = create_app('manager.spec.yaml')  # pylint: disable=invalid-name
 
 if __name__ == '__main__':
     application.run(host='0.0.0.0', port=8000)

--- a/tests/manager_tests/test_readonly.py
+++ b/tests/manager_tests/test_readonly.py
@@ -4,13 +4,13 @@
 Manager read only mode tests.
 """
 from manager import base
-from .vuln_testcase import FlaskTestCase, ADMIN_URL_BASE
+from .vuln_testcase import FlaskTestCase, FlaskTestCaseAdmin
 
 CSV_EXPORT_ENDPOINTS = ('cves/CVE-2016-1/affected_systems', 'systems',
                         'systems/00000000-0000-0000-0000-000000000004/cves', 'vulnerabilities/cves')
 
 
-class TestManager(FlaskTestCase):
+class TestReadOnly(FlaskTestCase):
 
     def test_status(self, monkeypatch):
         monkeypatch.setattr(base, 'READ_ONLY_MODE', 1)
@@ -22,12 +22,15 @@ class TestManager(FlaskTestCase):
         response = self.vfetch("systems/00000000-0000-0000-0000-000000000004/opt_out?value=true", data="", method="PATCH")
         assert response.status_code == 503
 
-    def test_refresh(self, monkeypatch):
-        monkeypatch.setattr(base, 'READ_ONLY_MODE', 1)
-        response = self.vfetch("refresh/accounts/0", turnpike=True, url_base=ADMIN_URL_BASE, method="PUT")
-        assert response.status_code == 503
-
     def test_delete(self, monkeypatch):
         monkeypatch.setattr(base, 'READ_ONLY_MODE', 1)
         response = self.vfetch("systems/00000000-0000-0000-0000-000000000004", method="DELETE")
+        assert response.status_code == 503
+
+
+class TestReadOnlyAdmin(FlaskTestCaseAdmin):
+
+    def test_refresh(self, monkeypatch):
+        monkeypatch.setattr(base, 'READ_ONLY_MODE', 1)
+        response = self.vfetch("refresh/accounts/0", turnpike=True, method="PUT")
         assert response.status_code == 503

--- a/tests/manager_tests/test_refresh_handler.py
+++ b/tests/manager_tests/test_refresh_handler.py
@@ -5,10 +5,10 @@ import pytest
 
 from manager.base import ApplicationException
 from manager.refresh_handler import Refresh
-from .vuln_testcase import FlaskTestCase, ADMIN_URL_BASE
+from .vuln_testcase import FlaskTestCaseAdmin
 
 
-class TestRefreshHandler(FlaskTestCase):
+class TestRefreshHandler(FlaskTestCaseAdmin):
 
     @staticmethod
     def test_none_args():
@@ -26,23 +26,23 @@ class TestRefreshHandler(FlaskTestCase):
         assert exc.value.status_code == 400
 
     def test_refresh_account(self):
-        self.vfetch('refresh/accounts/0', method='PUT', url_base=ADMIN_URL_BASE).check_response(401)
-        self.vfetch('refresh/accounts/INVALID', turnpike=True, method='PUT', url_base=ADMIN_URL_BASE).check_response(404)
-        self.vfetch('refresh/accounts/0', turnpike=True, method='PUT', url_base=ADMIN_URL_BASE).check_response()
+        self.vfetch('refresh/accounts/0', method='PUT').check_response(401)
+        self.vfetch('refresh/accounts/INVALID', turnpike=True, method='PUT').check_response(404)
+        self.vfetch('refresh/accounts/0', turnpike=True, method='PUT').check_response()
 
     def test_refresh_account_cve(self):
-        self.vfetch('refresh/accounts/0/cves/CVE-2014-1', method='PUT', url_base=ADMIN_URL_BASE).check_response(401)
-        self.vfetch('refresh/accounts/INVALID/cves/INVALID', turnpike=True, method='PUT', url_base=ADMIN_URL_BASE).check_response(404)
-        self.vfetch('refresh/accounts/INVALID/cves/CVE-2014-1', turnpike=True, method='PUT', url_base=ADMIN_URL_BASE).check_response(404)
-        self.vfetch('refresh/accounts/0/cves/INVALID', turnpike=True, method='PUT', url_base=ADMIN_URL_BASE).check_response(404)
-        self.vfetch('refresh/accounts/0/cves/CVE-2014-1', turnpike=True, method='PUT', url_base=ADMIN_URL_BASE).check_response()
+        self.vfetch('refresh/accounts/0/cves/CVE-2014-1', method='PUT').check_response(401)
+        self.vfetch('refresh/accounts/INVALID/cves/INVALID', turnpike=True, method='PUT').check_response(404)
+        self.vfetch('refresh/accounts/INVALID/cves/CVE-2014-1', turnpike=True, method='PUT').check_response(404)
+        self.vfetch('refresh/accounts/0/cves/INVALID', turnpike=True, method='PUT').check_response(404)
+        self.vfetch('refresh/accounts/0/cves/CVE-2014-1', turnpike=True, method='PUT').check_response()
 
     def test_refresh_cve(self):
-        self.vfetch('refresh/cves/CVE-2014-1', method='PUT', url_base=ADMIN_URL_BASE).check_response(401)
-        self.vfetch('refresh/cves/INVALID', turnpike=True, method='PUT', url_base=ADMIN_URL_BASE).check_response(404)
-        self.vfetch('refresh/cves/CVE-2014-1', turnpike=True, method='PUT', url_base=ADMIN_URL_BASE).check_response()
+        self.vfetch('refresh/cves/CVE-2014-1', method='PUT').check_response(401)
+        self.vfetch('refresh/cves/INVALID', turnpike=True, method='PUT').check_response(404)
+        self.vfetch('refresh/cves/CVE-2014-1', turnpike=True, method='PUT').check_response()
 
     def test_refresh_system(self):
-        self.vfetch('refresh/systems/00000000-0000-0000-0000-000000000002', method='PUT', url_base=ADMIN_URL_BASE).check_response(401)
-        self.vfetch('refresh/systems/11111111-1111-1111-1111-000000000001', turnpike=True, method='PUT', url_base=ADMIN_URL_BASE).check_response(404)
-        self.vfetch('refresh/systems/00000000-0000-0000-0000-000000000002', turnpike=True, method='PUT', url_base=ADMIN_URL_BASE).check_response()
+        self.vfetch('refresh/systems/00000000-0000-0000-0000-000000000002', method='PUT').check_response(401)
+        self.vfetch('refresh/systems/11111111-1111-1111-1111-000000000001', turnpike=True, method='PUT').check_response(404)
+        self.vfetch('refresh/systems/00000000-0000-0000-0000-000000000002', turnpike=True, method='PUT').check_response()

--- a/tests/manager_tests/vuln_testcase.py
+++ b/tests/manager_tests/vuln_testcase.py
@@ -13,7 +13,6 @@ from manager import main
 from .schemas import SCHEMA_MAP
 
 URL_BASE = "/api/vulnerability/v1"
-ADMIN_URL_BASE = "/admin/api/vulnerability/v1"
 
 IDENTITY = {
     "identity": {
@@ -70,12 +69,12 @@ class FlaskTestCase:
     @pytest.fixture
     def app(self):  # pylint: disable=no-self-use
         """Fixture for the application"""
-        connexion_app = main.create_app()
+        connexion_app = main.create_app('manager.spec.yaml')
         return connexion_app.app
 
-    def vfetch(self, path, turnpike=False, url_base=URL_BASE, **kwargs):
+    def vfetch(self, path, turnpike=False, **kwargs):
         """Fetch method for vulnerability API."""
-        path = "{}/{}".format(url_base, path.lstrip("/"))
+        path = "{}/{}".format(URL_BASE, path.lstrip("/"))
         headers = kwargs.get("headers") or {}
         if turnpike:
             headers.update(RH_TURNPIKE_IDENTITY_HEADER)
@@ -101,6 +100,20 @@ class FlaskTestCase:
         """Raw get to an URI without headers"""
         response = self.client.get(path, **kwargs)  # pylint: disable=no-member
         return EngineResponse(response, "GET", path)
+
+
+@pytest.mark.usefixtures('client_class')
+class FlaskTestCaseAdmin(FlaskTestCase):
+    """Base class for vulnerability engine manager admin test cases"""
+    @pytest.fixture
+    def app(self):  # pylint: disable=no-self-use
+        """Fixture for the application"""
+        connexion_app = main.create_app('manager.admin.spec.yaml')
+        return connexion_app.app
+
+    def vfetch(self, path, turnpike=False, **kwargs):
+        """Fetch method for vulnerability API."""
+        return super().vfetch(path, turnpike=turnpike, **kwargs)
 
 
 class EngineResponse:


### PR DESCRIPTION
because it's not possible to make Swagger UI work with /admin/api/vulnerability here and /api/vulnerability in turnpike proxy
I was unsuccesful with setting connexion to serve openapi.json with fixed url