### PR TITLE
chore: reload workers when code changes

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,6 +11,8 @@ if [[ ! -z $1 ]]; then
         exec python3 -m vmaas_sync.vmaas_sync
     elif [[ "$1" == "manager" ]]; then
         exec gunicorn -c manager/gunicorn_conf.py -w ${GUNICORN_WORKERS:-4} --bind=0.0.0.0:8000 --timeout=60 manager.main
+    elif [[ "$1" == "manager-dev" ]]; then
+        exec gunicorn --reload -c manager/gunicorn_conf.py -w ${GUNICORN_WORKERS:-4} --bind=0.0.0.0:8000 --timeout=60 manager.main
     elif [[ "$1" == "manager-admin" ]]; then
         exec gunicorn -c manager/gunicorn_conf.py -w ${GUNICORN_WORKERS:-4} --bind=0.0.0.0:8000 --timeout=60 manager.admin
     elif [[ "$1" == "advisor-listener" ]]; then


### PR DESCRIPTION
Please feel free to close the PR if it's not suitable for the project. 
However, the "watchers" in the frontend are extremely useful (so it might be for the backend) cause you don't have to kill the process every single time but instead it reloads when the code changes. 

https://docs.gunicorn.org/en/19.0/settings.html#reload

