### PR TITLE
VULN-1380,VULN-1069: feat(manager): display live counts in /vulnerabilities/cves API

### DIFF
--- a/manager/cve_handler.py
+++ b/manager/cve_handler.py
@@ -41,7 +41,7 @@ class AffectedSystemsView(ListView):
             filters.append(filter_types.SYSTEM_SAP)
             filters.append(filter_types.SYSTEM_SAP_SIDS)
 
-        query = apply_filters(query, filter_args, filters)
+        query = apply_filters(query, filter_args, filters, {})
 
         query = query.dicts()
 
@@ -60,8 +60,9 @@ class AffectedSystemsView(ListView):
         filterable_columns = {
             'display_name': SystemPlatform.display_name
         }
+        filter_expressions = {}
         super(AffectedSystemsView, self).__init__(query, sortable_columns, default_sort_columns,
-                                                  filterable_columns, list_args, parsed_args, uri)
+                                                  filterable_columns, filter_expressions, list_args, parsed_args, uri)
 
     @staticmethod
     def _full_query(synopsis, query_args):

--- a/manager/filters.py
+++ b/manager/filters.py
@@ -9,7 +9,7 @@ from peewee import fn
 from common.peewee_model import CveAccountData, CveMetadata, CveRuleMapping, InsightsRule, SystemPlatform, SystemVulnerabilities, InventoryHosts
 
 
-def _filter_cve_by_business_risk(query, args):
+def _filter_cve_by_business_risk(query, args, _kwargs):
     """
     Filters list of CVEs based on their business risk. Query has to contain CveAccountData table.
 
@@ -25,7 +25,7 @@ def _filter_cve_by_business_risk(query, args):
     return query
 
 
-def _filter_cve_by_cvss(query, args):
+def _filter_cve_by_cvss(query, args, _kwargs):
     """
     Filters list of CVEs based on their CVSS score. Query has to contain CveMetadata table.
 
@@ -52,7 +52,7 @@ def _filter_cve_by_cvss(query, args):
     return query
 
 
-def _filter_cve_by_impact(query, args):
+def _filter_cve_by_impact(query, args, _kwargs):
     """
     Filters list of CVEs based on their impact. Query has to contain CveMetadata table.
 
@@ -68,7 +68,7 @@ def _filter_cve_by_impact(query, args):
     return query
 
 
-def _filter_cve_by_public_date(query, args):
+def _filter_cve_by_public_date(query, args, _kwargs):
     """
     Filters list of CVEs based on their public date. Query has to contain CveMetadata table.
 
@@ -86,7 +86,7 @@ def _filter_cve_by_public_date(query, args):
     return query
 
 
-def _filter_cve_by_rule_presence(query, args):
+def _filter_cve_by_rule_presence(query, args, _kwargs):
     """
     Filters list of CVEs based on presence of rule. Query has to contain CveMetadata, CveRuleMapping and InsightsRule tables.
 
@@ -119,7 +119,7 @@ def _filter_cve_by_rule_presence(query, args):
     return query
 
 
-def _filter_cve_by_rule_presence_old(query, args):
+def _filter_cve_by_rule_presence_old(query, args, _kwargs):
     """
     Filters list of CVEs based on presence of rule. Query has to contain CveMetadata, CveRuleMapping and InsightsRule tables.
     Will get deleted later.
@@ -131,36 +131,18 @@ def _filter_cve_by_rule_presence_old(query, args):
     """
     if 'security_rule' in args and args['security_rule'] is not None:
         args['rule_presence'] = [args['security_rule']]
-        return _filter_cve_by_rule_presence(query, args)
+        return _filter_cve_by_rule_presence(query, args, _kwargs)
     return query
 
 
-def _filter_cve_by_show_all(query, args):
+def _filter_cve_by_affecting(query, args, kwargs):
     """
     Filters list of CVEs based on the fact whether CVE applies at least to one system or not. Query has to contain CveAccountData table.
 
     Args:
         query (object): Query object to apply filters to
         args (dict): Query arguemnts
-
-    Returns:
-        object: Modified query with show all filter applied
-    """
-    # pylint: disable=singleton-comparison
-    if args['affecting'] is not None:
-        return query
-    if 'show_all' in args and args['show_all'] == False:  # noqa: E712
-        query = query.where(CveAccountData.systems_affected > 0)
-    return query
-
-
-def _filter_cve_by_affecting(query, args):
-    """
-    Filters list of CVEs based on the fact whether CVE applies at least to one system or not. Query has to contain CveAccountData table.
-
-    Args:
-        query (object): Query object to apply filters to
-        args (dict): Query arguemnts
+        kwargs (dict): subquery object
 
     Returns:
         object: Modified query with affecting filter applied
@@ -168,15 +150,14 @@ def _filter_cve_by_affecting(query, args):
     if args['show_all'] is not None or args['affecting'] is None:
         return query
 
-    if args['affecting'] == [True, False]:
-        query = query.where(CveAccountData.systems_affected > 0)
-    elif args['affecting'] == [False, True]:
-        query = query.where(CveAccountData.systems_affected.is_null(True))
+    if args['affecting'] == [False, True]:
+        count_subquery = kwargs["count_subquery"]
+        query = query.where(fn.COALESCE(count_subquery.c.systems_affected_, 0) == 0)
 
     return query
 
 
-def _filter_cve_by_status(query, args):
+def _filter_cve_by_status(query, args, _kwargs):
     """
     Filters list of CVEs based on their global status. Query has to contain CveAccountData table.
 
@@ -192,7 +173,7 @@ def _filter_cve_by_status(query, args):
     return query
 
 
-def _filter_system_by_uuid(query, args):
+def _filter_system_by_uuid(query, args, _kwargs):
     """
     Filters list of systems based on their UUID. Query has to contain SystemPlatform table.
 
@@ -208,7 +189,7 @@ def _filter_system_by_uuid(query, args):
     return query
 
 
-def _filter_system_by_opt_out(query, args):
+def _filter_system_by_opt_out(query, args, _kwargs):
     """
     Filters list of systems based on their opt out status. Query has to contain SystemPlatform table.
 
@@ -230,7 +211,7 @@ def _filter_system_by_opt_out(query, args):
     return query
 
 
-def _filter_system_by_excluded(query, args):
+def _filter_system_by_excluded(query, args, _kwargs):
     """
     Filters list of systems based on their opt_out status. Query has to contain SystemPlatform table.
 
@@ -253,7 +234,7 @@ def _filter_system_by_excluded(query, args):
     return query
 
 
-def _filter_system_by_stale(query, args):
+def _filter_system_by_stale(query, args, _kwargs):
     """
     Filters list of systems based on stale status. Query has to contain SystemPlatform table.
 
@@ -272,7 +253,7 @@ def _filter_system_by_stale(query, args):
     return query
 
 
-def _filter_system_cve_by_rule(query, args):
+def _filter_system_cve_by_rule(query, args, _kwargs):
     """
     Filters list of CVEs based on presence/name of security rule. Query has to contain left outer joined table.
     Filtering is done on match of the rule name.
@@ -289,7 +270,7 @@ def _filter_system_cve_by_rule(query, args):
     return query
 
 
-def _filter_system_cve_by_rule_presence(query, args):
+def _filter_system_cve_by_rule_presence(query, args, _kwargs):
     """
     Filters CVEs if they have rules or not. Argument can be either
     single bool, or list of bools.
@@ -318,7 +299,7 @@ def _filter_system_cve_by_rule_presence(query, args):
     return query
 
 
-def _filter_system_cve_by_rule_old(query, args):
+def _filter_system_cve_by_rule_old(query, args, _kwargs):
     """
     Filters list of CVEs based on presence/name of security rule. Query has to contain left outer joined table.
     If query is bool - is filtered by rule presence.
@@ -333,14 +314,14 @@ def _filter_system_cve_by_rule_old(query, args):
     if 'security_rule' in args and args['security_rule'] is not None:
         if isinstance(args['security_rule'], bool):
             args['rule_presence'] = [args['security_rule']]
-            query = _filter_system_cve_by_rule_presence(query, args)
+            query = _filter_system_cve_by_rule_presence(query, args, _kwargs)
         elif isinstance(args['security_rule'], list):
             args['rule_key'] = args['security_rule']
-            query = _filter_system_cve_by_rule(query, args)
+            query = _filter_system_cve_by_rule(query, args, _kwargs)
     return query
 
 
-def _filter_system_cve_by_status(query, args):
+def _filter_system_cve_by_status(query, args, _kwargs):
     """
     Filters list of system CVEs based on their individiual system-cve pair status. Query has to contain SystemVulnerabilities table.
 
@@ -356,7 +337,7 @@ def _filter_system_cve_by_status(query, args):
     return query
 
 
-def _filter_system_by_tags(query, args):
+def _filter_system_by_tags(query, args, _kwargs):
     """
     Filters list of systems based on given tags.
     Query needs to be joined with cyndi inventory.hosts view!
@@ -374,7 +355,7 @@ def _filter_system_by_tags(query, args):
     return query
 
 
-def _filter_system_by_sap(query, args):
+def _filter_system_by_sap(query, args, _kwargs):
     """
     Filters list of systems based if system is managed by SAP.
     This information is stored inside cyndi view.
@@ -395,7 +376,7 @@ def _filter_system_by_sap(query, args):
     return query
 
 
-def _filter_system_by_sap_sids(query, args):
+def _filter_system_by_sap_sids(query, args, _kwargs):
     """[summary]
     Filters list of systems based on its SAP sids.
     This information is stored inside cyndi view.
@@ -427,7 +408,6 @@ class filter_types(Enum):  # pylint: disable=invalid-name
     CVE_IMPACT = _filter_cve_by_impact
     CVE_RULE_PRESENCE = _filter_cve_by_rule_presence
     CVE_RULE_PRESENCE_OLD = _filter_cve_by_rule_presence_old
-    CVE_SHOW_ALL = _filter_cve_by_show_all
     CVE_AFFECTING = _filter_cve_by_affecting
     CVE_STATUS = _filter_cve_by_status
     SYSTEM_CVE_RULE = _filter_system_cve_by_rule
@@ -443,7 +423,7 @@ class filter_types(Enum):  # pylint: disable=invalid-name
     SYSTEM_SAP_SIDS = _filter_system_by_sap_sids
 
 
-def apply_filters(query, args, filters):
+def apply_filters(query, args, filters, kwargs):
     """
     Apply all filters on query object
 
@@ -451,11 +431,12 @@ def apply_filters(query, args, filters):
         query (object): Query object to apply filters to
         args (dict): Query arguemnts
         filters ([filter_types]): List of filter_types objects
+        kwargs (dict): Support arguments passed from code, e.g. subquery object
 
     Returns:
         object: Modified query with all filters applied
     """
     filters_set = set(filters)
     for query_filter in filters_set:
-        query = query_filter(query, args)
+        query = query_filter(query, args, kwargs)
     return query

--- a/manager/list_view.py
+++ b/manager/list_view.py
@@ -12,12 +12,14 @@ class ListView:
 
     # handling both pagination and limit/offset drove us over the limit
 
-    def __init__(self, query, sortable_columns, default_sort_columns, filterable_columns, list_args, query_args, uri):
+    def __init__(self, query, sortable_columns, default_sort_columns, filterable_columns, filter_expressions,
+                 list_args, query_args, uri):
         self.uri = uri.split('?')[0]
         self.query = query
         self.sortable_columns = sortable_columns
         self.default_sort_columns = default_sort_columns
         self.filterable_columns = filterable_columns
+        self.filter_expressions = filter_expressions
         self.list_args = list_args
         self.query_args = query_args
 
@@ -37,14 +39,19 @@ class ListView:
 
     def _apply_filter(self):
         if self.list_args["filter"]:
-            if not self.filterable_columns:
-                raise InvalidArgumentException("No available columns for filtering")
+            if not self.filterable_columns and not self.filter_expressions:
+                raise InvalidArgumentException("No available columns or expressions for filtering")
             expressions = None
             for column in self.filterable_columns.values():
                 if expressions is None:
                     expressions = column.contains(self.list_args["filter"])
                 else:
                     expressions |= column.contains(self.list_args["filter"])
+            for filter_expression in self.filter_expressions.values():
+                if expressions is None:
+                    expressions = filter_expression
+                else:
+                    expressions |= filter_expression
             self.query = self.query.where(expressions)
 
     def _apply_sort(self):
@@ -58,7 +65,6 @@ class ListView:
             raise InvalidArgumentException("No available columns for sorting")
 
         sort_columns = []
-        distinct_columns = []
         for column_name in input_sort_columns:
             column_name, desc = self._parse_column_name(column_name)
             db_column_list = self.sortable_columns.get(column_name, None)
@@ -71,9 +77,8 @@ class ListView:
                     sort_columns.append(db_column.desc(nulls='LAST'))
                 else:
                     sort_columns.append(db_column.asc())
-                distinct_columns.append(db_column)
         if sort_columns:
-            self.query = self.query.distinct(*distinct_columns).order_by(*sort_columns)
+            self.query = self.query.order_by(*sort_columns)
 
     def _get_total_items(self, total_items=None):
         if total_items is None:

--- a/manager/system_handler.py
+++ b/manager/system_handler.py
@@ -32,7 +32,7 @@ class SystemCvesView(ListView):
         query = cyndi_query(query)
         query = apply_filters(query, filter_args, [filter_types.CVE_BUSINESS_RISK, filter_types.CVE_CVSS, filter_types.CVE_IMPACT,
                                                    filter_types.CVE_PUBLIC_DATE, filter_types.SYSTEM_CVE_STATUS, filter_types.SYSTEM_CVE_RULE_PRESENCE,
-                                                   filter_types.SYSTEM_CVE_RULE_OLD])
+                                                   filter_types.SYSTEM_CVE_RULE_OLD], {})
         query = query.dicts()
 
         sortable_columns = {
@@ -59,8 +59,9 @@ class SystemCvesView(ListView):
             'status': Status.name,
             "rule_description": InsightsRule.description_text
         }
+        filter_expressions = {}
         super(SystemCvesView, self).__init__(query, sortable_columns, default_sort_columns,
-                                             filterable_columns, list_args, parsed_args, uri)
+                                             filterable_columns, filter_expressions, list_args, parsed_args, uri)
 
     @staticmethod
     def _full_query(query_args):
@@ -147,7 +148,7 @@ class SystemView(ListView):
             filters.append(filter_types.SYSTEM_SAP)
             filters.append(filter_types.SYSTEM_SAP_SIDS)
 
-        query = apply_filters(query, filter_args, filters)
+        query = apply_filters(query, filter_args, filters, {})
 
         sortable_columns = {
             'id': SystemPlatform.id,
@@ -163,8 +164,9 @@ class SystemView(ListView):
         filterable_columns = {
             'display_name': SystemPlatform.display_name
         }
+        filter_expressions = {}
         super(SystemView, self).__init__(query, sortable_columns, default_sort_columns,
-                                         filterable_columns, list_args, parsed_args, uri)
+                                         filterable_columns, filter_expressions, list_args, parsed_args, uri)
 
     @staticmethod
     def _full_query(query_args):

--- a/manager/vulnerabilities_handler.py
+++ b/manager/vulnerabilities_handler.py
@@ -7,7 +7,8 @@ import dateutil.parser
 import connexion
 from peewee import Case, fn, JOIN, SQL
 
-from common.peewee_model import BusinessRisk, CveAccountData, CveMetadata, CveImpact, RHAccount, Status, InsightsRule, CveRuleMapping
+from common.peewee_model import BusinessRisk, CveAccountData, CveMetadata, CveImpact, Status, InsightsRule, CveRuleMapping, SystemVulnerabilities, \
+    SystemPlatform
 from .base import DEFAULT_BUSINESS_RISK, DEFAULT_STATUS, GetRequest, parse_int_list, CVE_SYNOPSIS_SORT, get_rules_for_cves, get_system_count, get_account_id, \
                   unique_bool_list
 from .filters import apply_filters, filter_types
@@ -17,16 +18,16 @@ from .list_view import ListView
 class CvesListView(ListView):
     """Database select for CVEs affecting user systems"""
 
-    def __init__(self, list_args, query_args, uri, args, ids_only=False):
+    def __init__(self, rh_account_id, list_args, query_args, uri, args):
         join_type = JOIN.INNER
-        cve_count = CveAccountData.systems_affected
         if ('show_all' in args and args['show_all']) or (args['affecting'] is None or args['affecting'][1] or not args['affecting'][0]):
-            join_type = JOIN.RIGHT_OUTER
-            cve_count = fn.COALESCE(cve_count, 0)
-        query = self._full_query(cve_count, join_type, query_args) if not ids_only else self._id_query(join_type, query_args)
-        query = apply_filters(query, args, [filter_types.CVE_BUSINESS_RISK, filter_types.CVE_CVSS, filter_types.CVE_IMPACT, filter_types.CVE_PUBLIC_DATE,
-                                            filter_types.CVE_RULE_PRESENCE, filter_types.CVE_SHOW_ALL, filter_types.CVE_STATUS,
-                                            filter_types.CVE_RULE_PRESENCE_OLD, filter_types.CVE_AFFECTING])
+            join_type = JOIN.LEFT_OUTER
+        count_subquery = self._count_subquery(rh_account_id)
+        query = self._full_query(rh_account_id, join_type, count_subquery)
+        query = apply_filters(query, args, [filter_types.CVE_BUSINESS_RISK, filter_types.CVE_CVSS, filter_types.CVE_IMPACT,
+                                            filter_types.CVE_PUBLIC_DATE, filter_types.CVE_RULE_PRESENCE, filter_types.CVE_STATUS,
+                                            filter_types.CVE_RULE_PRESENCE_OLD, filter_types.CVE_AFFECTING],
+                              {"count_subquery": count_subquery})
         query = query.dicts()
 
         sortable_columns = {
@@ -49,55 +50,64 @@ class CvesListView(ListView):
         filterable_columns = {
             "synopsis": CveMetadata.cve,
             "description": CveMetadata.description,
-            "rule_description": InsightsRule.description_text
+        }
+        filter_expressions = {
+            "rule_description": fn.Exists(CveRuleMapping
+                                          .select(CveRuleMapping.cve_id)
+                                          .join(InsightsRule, on=(CveRuleMapping.rule_id == InsightsRule.id))
+                                          .where(CveRuleMapping.cve_id == CveMetadata.id)
+                                          .where(InsightsRule.description_text.contains(list_args["filter"])))
         }
         default_sort_columns = ['id']
 
         super(CvesListView, self).__init__(query, sortable_columns, default_sort_columns,
-                                           filterable_columns, list_args, args, uri)
+                                           filterable_columns, filter_expressions, list_args, args, uri)
 
     @staticmethod
-    def _full_query(cve_count, join_type, query_args):
+    def _full_query(rh_account_id, join_type, count_subquery):
         return (
-            CveAccountData
-            .select(cve_count.alias("systems_affected"),
-                    CveMetadata.id.alias('cve_id'),
+            CveMetadata
+            .select(CveMetadata.id.alias("cve_id"),
                     CveMetadata.cve.alias("cve_name"),
                     CveMetadata.cvss3_score,
                     CveMetadata.cvss2_score,
                     CveMetadata.impact_id,
                     CveMetadata.public_date,
                     CveMetadata.description.alias("cve_description"),
-                    fn.COALESCE(CveAccountData.business_risk_id, 0).alias('business_risk_id'),
-                    CveAccountData.business_risk_text.alias('business_risk_text'),
-                    fn.COALESCE(BusinessRisk.name, DEFAULT_BUSINESS_RISK).alias('business_risk'),
-                    fn.COALESCE(CveAccountData.status_id, 0).alias('status_id'),
-                    CveAccountData.status_text.alias('status_text'),
-                    fn.COALESCE(Status.name, DEFAULT_STATUS).alias('status'),
-                    fn.COALESCE(CveAccountData.systems_status_divergent, 0).alias('systems_status_divergent'))
-            .join(RHAccount, on=(CveAccountData.rh_account_id == RHAccount.id))
-            .join(CveMetadata, join_type,
-                  on=((CveAccountData.cve_id == CveMetadata.id)
-                      & (RHAccount.name == query_args["rh_account_number"])))
+                    fn.COALESCE(CveAccountData.business_risk_id, 0).alias("business_risk_id"),
+                    CveAccountData.business_risk_text.alias("business_risk_text"),
+                    fn.COALESCE(BusinessRisk.name, DEFAULT_BUSINESS_RISK).alias("business_risk"),
+                    fn.COALESCE(CveAccountData.status_id, 0).alias("status_id"),
+                    CveAccountData.status_text.alias("status_text"),
+                    fn.COALESCE(Status.name, DEFAULT_STATUS).alias("status"),
+                    fn.COALESCE(count_subquery.c.systems_affected_, 0).alias("systems_affected"),
+                    fn.COALESCE(count_subquery.c.systems_status_divergent_, 0).alias("systems_status_divergent"))
+            .join(count_subquery, join_type, on=(CveMetadata.id == count_subquery.c.cve_id_))
+            .join(CveAccountData, JOIN.LEFT_OUTER, on=((CveMetadata.id == CveAccountData.cve_id)
+                                                       & (CveAccountData.rh_account_id == rh_account_id)))
             .join(BusinessRisk, JOIN.LEFT_OUTER, on=(CveAccountData.business_risk_id == BusinessRisk.id))
             .join(Status, JOIN.LEFT_OUTER, on=(CveAccountData.status_id == Status.id))
-            .join(CveRuleMapping, JOIN.LEFT_OUTER, on=(CveMetadata.id == CveRuleMapping.cve_id))
-            .join(InsightsRule, JOIN.LEFT_OUTER, on=(CveRuleMapping.rule_id == InsightsRule.id))
         )
 
     @staticmethod
-    def _id_query(join_type, query_args):
+    def _count_subquery(rh_account_id):
         return (
-            CveAccountData
-            .select(CveMetadata.cve.alias('cve_name'),)
-            .join(RHAccount, on=(CveAccountData.rh_account_id == RHAccount.id))
-            .join(CveMetadata, join_type,
-                  on=((CveAccountData.cve_id == CveMetadata.id)
-                      & (RHAccount.name == query_args["rh_account_number"])))
-            .join(BusinessRisk, JOIN.LEFT_OUTER, on=(CveAccountData.business_risk_id == BusinessRisk.id))
-            .join(Status, JOIN.LEFT_OUTER, on=(CveAccountData.status_id == Status.id))
-            .join(CveRuleMapping, JOIN.LEFT_OUTER, on=(CveMetadata.id == CveRuleMapping.cve_id))
-            .join(InsightsRule, JOIN.LEFT_OUTER, on=(CveRuleMapping.rule_id == InsightsRule.id))
+            # pylint: disable=singleton-comparison
+            SystemVulnerabilities
+            .select(SystemVulnerabilities.cve_id.alias("cve_id_"),
+                    fn.Count(SystemVulnerabilities.id).alias("systems_affected_"),
+                    fn.Sum(Case(None, ((SystemVulnerabilities.status_id != CveAccountData.status_id, 1),), 0)).alias("systems_status_divergent_"))
+            .join(SystemPlatform, on=(SystemVulnerabilities.system_id == SystemPlatform.id))
+            .join(InsightsRule, JOIN.LEFT_OUTER, on=(SystemVulnerabilities.rule_id == InsightsRule.id))
+            .join(CveAccountData, JOIN.LEFT_OUTER, on=((SystemVulnerabilities.cve_id == CveAccountData.cve_id)
+                                                       & (SystemVulnerabilities.rh_account_id == CveAccountData.rh_account_id)))
+            .where(SystemVulnerabilities.rh_account_id == rh_account_id)
+            .where((SystemVulnerabilities.mitigation_reason.is_null(True)) | (InsightsRule.active == False))
+            .where((SystemVulnerabilities.when_mitigated.is_null(True)) | (InsightsRule.active == True))
+            .where((SystemPlatform.opt_out == False)  # noqa: E712
+                   & (SystemPlatform.stale == False)  # noqa: E712
+                   & (SystemPlatform.when_deleted.is_null(True)))
+            .group_by(SystemVulnerabilities.cve_id)
         )
 
 
@@ -130,14 +140,14 @@ class GetCves(GetRequest):
                      {'arg_name': 'affecting', 'convert_func': None}]
         args = cls._parse_arguments(kwargs, args_desc)
         list_arguments = cls._parse_list_arguments(kwargs)
-        cves_view = CvesListView(list_arguments, {"rh_account_number": connexion.context['user']},
-                                 connexion.request.path, args, cls._ids_only)
+        rh_account_id = get_account_id(connexion.context['user'])
+        cves_view = CvesListView(rh_account_id, list_arguments, {"rh_account_number": connexion.context['user']},
+                                 connexion.request.path, args)
         res = {}
         res["meta"] = cves_view.get_metadata()
         res["links"] = cves_view.get_pagination_links()
         res["data"] = cls._format_data(list_arguments["data_format"], cls.assign_cves(cves_view))
 
-        rh_account_id = get_account_id(connexion.context['user'])
         res["meta"]["system_count"] = get_system_count(rh_account_id)
         return res
 
@@ -150,8 +160,9 @@ class GetCves(GetRequest):
                 result.append(row['cve_name'])
         else:
             impact_id_map = _prepare_impact_id_map()
-            rules_map = get_rules_for_cves([row['cve_id'] for row in cves_view])
-            for row in cves_view:
+            cves_materialized = list(cves_view)  # execute query
+            rules_map = get_rules_for_cves([row['cve_id'] for row in cves_materialized])
+            for row in cves_materialized:
                 entry = dict()
                 res = {}
                 entry["systems_affected"] = row["systems_affected"]

--- a/tests/manager_tests/test_links.py
+++ b/tests/manager_tests/test_links.py
@@ -19,6 +19,7 @@ SORTABLE = {
 }
 DEFAULT_SORT = ['id']
 FILTERABLE = {}
+FILTER_EXPRESSIONS = {}
 QUERY = (SystemPlatform.select(SystemPlatform.inventory_id))
 URI = 'http://localhost:6666/api/v1/vulnerability/systems'
 
@@ -49,10 +50,10 @@ class NoQueryListView(ListView):
     """Pseudo-view used to test the basic math/param-processing of ListView and links"""
 
     def __init__(self, query, sortable_columns, default_sort_columns, filterable_columns,
-                 list_args, query_args, uri, total):
+                 filter_expressions, list_args, query_args, uri, total):
         self.total_items = total
         super(NoQueryListView, self).__init__(query, sortable_columns, default_sort_columns, filterable_columns,
-                                              list_args, query_args, uri)
+                                              filter_expressions, list_args, query_args, uri)
 
     def _get_total_items(self, total_items=None):
         # Intercept so we can ignore the query
@@ -69,7 +70,7 @@ class NoQueryListView(ListView):
 class TestLinks(FlaskTestCase):
 
     def test_previous(self):
-        view = NoQueryListView(QUERY, SORTABLE, DEFAULT_SORT, FILTERABLE, LIST_ARGS, QUERY_ARGS, URI, TOTAL_ITEMS)
+        view = NoQueryListView(QUERY, SORTABLE, DEFAULT_SORT, FILTERABLE, FILTER_EXPRESSIONS, LIST_ARGS, QUERY_ARGS, URI, TOTAL_ITEMS)
         assert view._get_previous(0, LIMIT) == 0
         assert view._get_previous(20, LIMIT) == 15
         assert view._get_previous(120, LIMIT) == 115
@@ -77,7 +78,7 @@ class TestLinks(FlaskTestCase):
         assert view._get_previous(2, LIMIT) == 0
 
     def test_next(self):
-        view = NoQueryListView(QUERY, SORTABLE, DEFAULT_SORT, FILTERABLE, LIST_ARGS, QUERY_ARGS, URI, TOTAL_ITEMS)
+        view = NoQueryListView(QUERY, SORTABLE, DEFAULT_SORT, FILTERABLE, FILTER_EXPRESSIONS, LIST_ARGS, QUERY_ARGS, URI, TOTAL_ITEMS)
         assert view._get_next(0, LIMIT, TOTAL_ITEMS) == 5
         assert view._get_next(20, LIMIT, TOTAL_ITEMS) == 25
         assert view._get_next(120, LIMIT, TOTAL_ITEMS) == 125
@@ -85,7 +86,7 @@ class TestLinks(FlaskTestCase):
         assert view._get_next(2, LIMIT, TOTAL_ITEMS) == 5
 
     def test_last(self):
-        view = NoQueryListView(QUERY, SORTABLE, DEFAULT_SORT, FILTERABLE, LIST_ARGS, QUERY_ARGS, URI, TOTAL_ITEMS)
+        view = NoQueryListView(QUERY, SORTABLE, DEFAULT_SORT, FILTERABLE, FILTER_EXPRESSIONS, LIST_ARGS, QUERY_ARGS, URI, TOTAL_ITEMS)
         assert view._get_last(5, TOTAL_ITEMS) == 125
         assert view._get_last(3, 1) == 0
         assert view._get_last(3, 3) == 0
@@ -96,7 +97,7 @@ class TestLinks(FlaskTestCase):
     def test_first_link(self):
         LOCAL_LIST_ARGS = LIST_ARGS.copy()
         LOCAL_LIST_ARGS['offset'] = 0
-        view = NoQueryListView(QUERY, SORTABLE, DEFAULT_SORT, FILTERABLE, LOCAL_LIST_ARGS, QUERY_ARGS, URI,
+        view = NoQueryListView(QUERY, SORTABLE, DEFAULT_SORT, FILTERABLE, FILTER_EXPRESSIONS, LOCAL_LIST_ARGS, QUERY_ARGS, URI,
                                TOTAL_ITEMS)
         assert 'limit=%s' % (LIMIT) in view._get_first_link()
         assert 'offset=0' in view._get_first_link()
@@ -110,59 +111,59 @@ class TestLinks(FlaskTestCase):
     def test_prev_link(self):
         LOCAL_LIST_ARGS = LIST_ARGS.copy()
         LOCAL_LIST_ARGS['offset'] = 0
-        view = NoQueryListView(QUERY, SORTABLE, DEFAULT_SORT, FILTERABLE, LOCAL_LIST_ARGS, QUERY_ARGS, URI,
+        view = NoQueryListView(QUERY, SORTABLE, DEFAULT_SORT, FILTERABLE, FILTER_EXPRESSIONS, LOCAL_LIST_ARGS, QUERY_ARGS, URI,
                                TOTAL_ITEMS)
         assert view._get_previous_link() is None
 
         LOCAL_LIST_ARGS['offset'] = 20
-        view = NoQueryListView(QUERY, SORTABLE, DEFAULT_SORT, FILTERABLE, LOCAL_LIST_ARGS, QUERY_ARGS, URI,
+        view = NoQueryListView(QUERY, SORTABLE, DEFAULT_SORT, FILTERABLE, FILTER_EXPRESSIONS, LOCAL_LIST_ARGS, QUERY_ARGS, URI,
                                TOTAL_ITEMS)
         assert 'offset=15' in view._get_previous_link()
 
         LOCAL_LIST_ARGS['offset'] = 120
-        view = NoQueryListView(QUERY, SORTABLE, DEFAULT_SORT, FILTERABLE, LOCAL_LIST_ARGS, QUERY_ARGS, URI,
+        view = NoQueryListView(QUERY, SORTABLE, DEFAULT_SORT, FILTERABLE, FILTER_EXPRESSIONS, LOCAL_LIST_ARGS, QUERY_ARGS, URI,
                                TOTAL_ITEMS)
         assert 'offset=115' in view._get_previous_link()
 
         LOCAL_LIST_ARGS['offset'] = 15
-        view = NoQueryListView(QUERY, SORTABLE, DEFAULT_SORT, FILTERABLE, LOCAL_LIST_ARGS, QUERY_ARGS, URI,
+        view = NoQueryListView(QUERY, SORTABLE, DEFAULT_SORT, FILTERABLE, FILTER_EXPRESSIONS, LOCAL_LIST_ARGS, QUERY_ARGS, URI,
                                TOTAL_ITEMS)
         assert 'offset=10' in view._get_previous_link()
 
         LOCAL_LIST_ARGS['offset'] = 2
-        view = NoQueryListView(QUERY, SORTABLE, DEFAULT_SORT, FILTERABLE, LOCAL_LIST_ARGS, QUERY_ARGS, URI,
+        view = NoQueryListView(QUERY, SORTABLE, DEFAULT_SORT, FILTERABLE, FILTER_EXPRESSIONS, LOCAL_LIST_ARGS, QUERY_ARGS, URI,
                                TOTAL_ITEMS)
         assert 'offset=0' in view._get_previous_link()
 
     def test_next_link(self):
         LOCAL_LIST_ARGS = LIST_ARGS.copy()
         LOCAL_LIST_ARGS['offset'] = 0
-        view = NoQueryListView(QUERY, SORTABLE, DEFAULT_SORT, FILTERABLE, LOCAL_LIST_ARGS, QUERY_ARGS, URI,
+        view = NoQueryListView(QUERY, SORTABLE, DEFAULT_SORT, FILTERABLE, FILTER_EXPRESSIONS, LOCAL_LIST_ARGS, QUERY_ARGS, URI,
                                TOTAL_ITEMS)
         assert 'offset=5' in view._get_next_link()
 
         LOCAL_LIST_ARGS['offset'] = 20
-        view = NoQueryListView(QUERY, SORTABLE, DEFAULT_SORT, FILTERABLE, LOCAL_LIST_ARGS, QUERY_ARGS, URI,
+        view = NoQueryListView(QUERY, SORTABLE, DEFAULT_SORT, FILTERABLE, FILTER_EXPRESSIONS, LOCAL_LIST_ARGS, QUERY_ARGS, URI,
                                TOTAL_ITEMS)
         assert 'offset=25' in view._get_next_link()
 
         LOCAL_LIST_ARGS['offset'] = 120
-        view = NoQueryListView(QUERY, SORTABLE, DEFAULT_SORT, FILTERABLE, LOCAL_LIST_ARGS, QUERY_ARGS, URI,
+        view = NoQueryListView(QUERY, SORTABLE, DEFAULT_SORT, FILTERABLE, FILTER_EXPRESSIONS, LOCAL_LIST_ARGS, QUERY_ARGS, URI,
                                TOTAL_ITEMS)
         assert 'offset=125' in view._get_next_link()
 
         LOCAL_LIST_ARGS['offset'] = 16
-        view = NoQueryListView(QUERY, SORTABLE, DEFAULT_SORT, FILTERABLE, LOCAL_LIST_ARGS, QUERY_ARGS, URI,
+        view = NoQueryListView(QUERY, SORTABLE, DEFAULT_SORT, FILTERABLE, FILTER_EXPRESSIONS, LOCAL_LIST_ARGS, QUERY_ARGS, URI,
                                TOTAL_ITEMS)
         assert 'offset=20' in view._get_next_link()
 
         LOCAL_LIST_ARGS['offset'] = 2
-        view = NoQueryListView(QUERY, SORTABLE, DEFAULT_SORT, FILTERABLE, LOCAL_LIST_ARGS, QUERY_ARGS, URI,
+        view = NoQueryListView(QUERY, SORTABLE, DEFAULT_SORT, FILTERABLE, FILTER_EXPRESSIONS, LOCAL_LIST_ARGS, QUERY_ARGS, URI,
                                TOTAL_ITEMS)
         assert 'offset=5' in view._get_next_link()
 
     def test_last_link(self):
-        view = NoQueryListView(QUERY, SORTABLE, DEFAULT_SORT, FILTERABLE, LIST_ARGS, QUERY_ARGS, URI, TOTAL_ITEMS)
+        view = NoQueryListView(QUERY, SORTABLE, DEFAULT_SORT, FILTERABLE, FILTER_EXPRESSIONS, LIST_ARGS, QUERY_ARGS, URI, TOTAL_ITEMS)
         assert 'offset=125' in view._get_last_link()
 
         args = LIST_ARGS.copy()
@@ -170,27 +171,27 @@ class TestLinks(FlaskTestCase):
         args['page_size'] = 3
         args['offset'] = 0
         args['limit'] = 3
-        view = NoQueryListView(QUERY, SORTABLE, DEFAULT_SORT, FILTERABLE, args, QUERY_ARGS, URI, 1)
+        view = NoQueryListView(QUERY, SORTABLE, DEFAULT_SORT, FILTERABLE, FILTER_EXPRESSIONS, args, QUERY_ARGS, URI, 1)
         assert 'offset=0' in view._get_last_link()
 
         args['total_items'] = 3
-        view = NoQueryListView(QUERY, SORTABLE, DEFAULT_SORT, FILTERABLE, args, QUERY_ARGS, URI, 3)
+        view = NoQueryListView(QUERY, SORTABLE, DEFAULT_SORT, FILTERABLE, FILTER_EXPRESSIONS, args, QUERY_ARGS, URI, 3)
         assert 'offset=0' in view._get_last_link()
 
         args['total_items'] = 5
-        view = NoQueryListView(QUERY, SORTABLE, DEFAULT_SORT, FILTERABLE, args, QUERY_ARGS, URI, 5)
+        view = NoQueryListView(QUERY, SORTABLE, DEFAULT_SORT, FILTERABLE, FILTER_EXPRESSIONS, args, QUERY_ARGS, URI, 5)
         assert 'offset=3' in view._get_last_link()
 
         args['total_items'] = 6
-        view = NoQueryListView(QUERY, SORTABLE, DEFAULT_SORT, FILTERABLE, args, QUERY_ARGS, URI, 6)
+        view = NoQueryListView(QUERY, SORTABLE, DEFAULT_SORT, FILTERABLE, FILTER_EXPRESSIONS, args, QUERY_ARGS, URI, 6)
         assert 'offset=3' in view._get_last_link()
 
         args['total_items'] = 7
-        view = NoQueryListView(QUERY, SORTABLE, DEFAULT_SORT, FILTERABLE, args, QUERY_ARGS, URI, 7)
+        view = NoQueryListView(QUERY, SORTABLE, DEFAULT_SORT, FILTERABLE, FILTER_EXPRESSIONS, args, QUERY_ARGS, URI, 7)
         assert 'offset=6' in view._get_last_link()
 
     def test_links_stanza(self):
-        view = NoQueryListView(QUERY, SORTABLE, DEFAULT_SORT, FILTERABLE, LIST_ARGS, QUERY_ARGS, URI, TOTAL_ITEMS)
+        view = NoQueryListView(QUERY, SORTABLE, DEFAULT_SORT, FILTERABLE, FILTER_EXPRESSIONS, LIST_ARGS, QUERY_ARGS, URI, TOTAL_ITEMS)
         links = view.get_pagination_links()
         assert links['first'] == view._get_first_link()
         assert links['next'] == view._get_next_link()
@@ -198,7 +199,7 @@ class TestLinks(FlaskTestCase):
         assert links['last'] == view._get_last_link()
 
     def test_links_filters(self):
-        view = NoQueryListView(QUERY, SORTABLE, DEFAULT_SORT, FILTERABLE, LIST_ARGS, QUERY_ARGS, URI, TOTAL_ITEMS)
+        view = NoQueryListView(QUERY, SORTABLE, DEFAULT_SORT, FILTERABLE, FILTER_EXPRESSIONS, LIST_ARGS, QUERY_ARGS, URI, TOTAL_ITEMS)
         last_link = view._get_last_link()
         assert 'cvss_from=2001-01-01' in last_link
         assert 'cvss_to=2020-01-01' in last_link
@@ -209,6 +210,6 @@ class TestLinks(FlaskTestCase):
 
         args = QUERY_ARGS.copy()
         del args['show_all']
-        view = NoQueryListView(QUERY, SORTABLE, DEFAULT_SORT, args, LIST_ARGS, args, URI, TOTAL_ITEMS)
+        view = NoQueryListView(QUERY, SORTABLE, DEFAULT_SORT, args, FILTER_EXPRESSIONS, LIST_ARGS, args, URI, TOTAL_ITEMS)
         last_link = view._get_last_link()
         assert 'show_all=True' not in last_link


### PR DESCRIPTION
also changes:

* improving performance by avoiding calling distinct (required by CveRuleMapping join)
* fixed bug when SQL query is executed twice
* improved performance by splitting into subqueries and joining the result
* remove show all filter function as it can be done only using left join now
* removed separate _ids query as it was 90 % same as full one, extracting ids from full query now