### PR TITLE
fix(db): unbound variable in schema init

### DIFF
--- a/database/schema/init_schema.sh
+++ b/database/schema/init_schema.sh
@@ -7,7 +7,7 @@ if $PG_INITIALIZED ; then
     psql -U ${POSTGRESQL_USER} -d ${POSTGRESQL_DATABASE} -f ${CONTAINER_SCRIPTS_PATH}/start/ve_db_user_create_postgresql.sql
     psql -U ${POSTGRESQL_USER} -d ${POSTGRESQL_DATABASE} -f ${CONTAINER_SCRIPTS_PATH}/start/ve_db_postgresql.sql
 
-    if [[ "$CYNDI_MOCK" == "TRUE" ]]; then
+    if [[ "${CYNDI_MOCK:-}" == "TRUE" ]]; then
         psql -U ${POSTGRESQL_USER} -d ${POSTGRESQL_DATABASE} -f ${CONTAINER_SCRIPTS_PATH}/start/ve_db_dev_cyndi.sql
     fi
 


### PR DESCRIPTION
DB passwords are not set when deploying DB with empty volume because CYNDI_MOCK is unbound

1. init_schema fails with unbound error
2. openshift recreates the pod - logs from previous step are lost
3. init_shcema is now skipped and DB pod is running without any error in a log
4. no pod can connect to DB because passwords have not been set

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
