### PR TITLE
fix: db ssl with clowder

### DIFF
--- a/common/config.py
+++ b/common/config.py
@@ -127,8 +127,6 @@ class BaseConfig:
             self.sasl_mechanism = "PLAIN"
             self.sasl_plain_username = None
             self.sasl_plain_password = None
-        self.db_ssl_mode = os.getenv("POSTGRESQL_SSL_MODE", "prefer")
-        self.db_ssl_root_cert_path = os.getenv("POSTGRESQL_SSL_ROOT_CERT_PATH", "/opt/rds-ca/rds-cacert")
 
 
 # pylint: disable=too-many-instance-attributes
@@ -156,6 +154,8 @@ class Config(BaseConfig, metaclass=Singleton):
         self.db_pass = cfg.database.password
         self.db_host = cfg.database.hostname
         self.db_port = cfg.database.port
+        self.db_ssl_mode = cfg.database.sslMode or "prefer"
+        self.db_ssl_root_cert_path = cfg.database.rdsCa or "/opt/rds-ca/rds-cacert"
 
         self.cw_aws_access_key_id = cfg.logging.cloudwatch.accessKeyId
         self.cw_aws_secret_access_key = cfg.logging.cloudwatch.secretAccessKey
@@ -215,6 +215,8 @@ class Config(BaseConfig, metaclass=Singleton):
         self.db_pass = os.getenv("POSTGRESQL_PASSWORD", "ve_db_user_unknown_pwd").strip()
         self.db_host = os.getenv("POSTGRESQL_HOST", "ve_database").strip()
         self.db_port = int(os.getenv("POSTGRESQL_PORT", "5432").strip())
+        self.db_ssl_mode = os.getenv("POSTGRESQL_SSL_MODE", "prefer")
+        self.db_ssl_root_cert_path = os.getenv("POSTGRESQL_SSL_ROOT_CERT_PATH", "/opt/rds-ca/rds-cacert")
 
         self.cw_aws_access_key_id = os.environ.get("CW_AWS_ACCESS_KEY_ID")
         self.cw_aws_secret_access_key = os.environ.get("CW_AWS_SECRET_ACCESS_KEY")


### PR DESCRIPTION
- get `sslMode` and `rdsCa` form clowder conf
- try to fix `ConnectionError: PostgreSQL server at "vulnerability-engine-database:5432" rejected SSL upgrade`
  - According to https://github.com/MagicStack/asyncpg/blob/master/asyncpg/connect_utils.py#L517-L530, it looks like `ssl_is_advisory` is set only when `sslmode=prefer`, but in our case ssl context is provided and it (probably) didn't set `ssl_is_advisory`... hard to tell

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
