### PR TITLE
feat(manager): fix missing inconsistencies with cyndi

### DIFF
--- a/manager/base.py
+++ b/manager/base.py
@@ -510,6 +510,7 @@ def get_rules_for_cves(cves: list, rh_account=None) -> dict:
                                               (SystemPlatform.stale == False) & (SystemPlatform.opt_out == False)))  # noqa: E712
                     .where(SystemVulnerabilities.cve_id.in_(cves))
                     .where((SystemVulnerabilities.rh_account_id == rh_account) & (SystemVulnerabilities.mitigation_reason.is_null(True))))
+        subquery = cyndi_join(subquery)
     mapping = (CveRuleMapping.select(CveRuleMapping.cve_id, InsightsRule.name, InsightsRule.description_text, InsightsRule.summary_text,
                                      InsightsRule.reboot_required, InsightsRule.playbook_count, InsightsRule.change_risk,
                                      InsightsRule.kbase_node_id, InsightsRule.active, CveMetadata.cve, InsightsRule.rule_impact,
@@ -608,7 +609,7 @@ def parse_tags(tags_list):
     return tags
 
 
-def cyndi_query(query):
+def cyndi_join(query):
     """Function adds join on cyndi table, based if cyndi is enabled."""
     if CFG.cyndi_enabled:
         query = query.join(InventoryHosts, JOIN.INNER, on=(SystemPlatform.inventory_id == InventoryHosts.id))

--- a/manager/cve_handler.py
+++ b/manager/cve_handler.py
@@ -14,7 +14,7 @@ from common.peewee_model import BusinessRisk, CveAccountData, CveMetadata, DB, R
     Status, SystemPlatform, SystemVulnerabilities, CveImpact, InsightsRule, InventoryHosts
 from .base import ApplicationException, DEFAULT_BUSINESS_RISK, DEFAULT_STATUS, get_or_create_account, \
     GetRequest, parse_int_list, PatchRequest, get_rules_for_cves, parse_str_list, reporter, unique_bool_list, \
-    parse_tags, cyndi_query, ServiceAccess, \
+    parse_tags, cyndi_join, ServiceAccess, \
     get_advisories_per_cve_from_db, filter_by_advisory, get_account_id, has_advisory
 from .filters import apply_filters, filter_types
 from .list_view import ListView
@@ -28,7 +28,7 @@ class SystemCvesView(ListView):
 
     def __init__(self, rh_account_id, synopsis, list_args, filter_args, parsed_args, uri, ids_only=False, system_advisories=None):
         query = self._full_query(rh_account_id, synopsis) if not ids_only else self._id_query(rh_account_id, synopsis)
-        query = cyndi_query(query)
+        query = cyndi_join(query)
         filters = [filter_types.SYSTEM_CVE_RULE,
                    filter_types.SYSTEM_CVE_STATUS,
                    filter_types.SYSTEM_UUID,
@@ -295,7 +295,7 @@ class GetCves(GetRequest):
                          .dicts())
 
         divergent_systems = 0
-        status_detail = cyndi_query(status_detail)
+        status_detail = cyndi_join(status_detail)
         for row in status_detail:
             retval['systems_status_detail'][row['status_id']] = row['systems']
             if row['status_id'] != retval['status_id']:

--- a/manager/dashboard_handler.py
+++ b/manager/dashboard_handler.py
@@ -9,7 +9,7 @@ from peewee import fn, SQL
 from common.config import Config
 from common.logging import get_logger
 from common.peewee_model import CveMetadata, CveRuleMapping, InsightsRule, SystemVulnerabilities, SystemPlatform
-from .base import cyndi_query, get_account_id, GetRequest, get_system_count, parse_tags, round_to_100_percent, \
+from .base import cyndi_join, get_account_id, GetRequest, get_system_count, parse_tags, round_to_100_percent, \
     is_cyndi_request
 from .filters import apply_filters, filter_types
 
@@ -85,7 +85,7 @@ class GetDashboard(GetRequest):
                                        (SystemVulnerabilities.rule_id << InsightsRule.select(InsightsRule.id)
                                         .where((InsightsRule.active == True) & (~InsightsRule.rule_only)))))
         if cyndi_request:
-            active_cves_subquery = cyndi_query(active_cves_subquery)
+            active_cves_subquery = cyndi_join(active_cves_subquery)
             active_cves_subquery = apply_filters(active_cves_subquery, args,
                                                  [filter_types.SYSTEM_TAGS, filter_types.SYSTEM_SAP, filter_types.SYSTEM_SAP_SIDS], {})
 
@@ -152,7 +152,7 @@ class GetDashboard(GetRequest):
                            )
 
         if cyndi_request:
-            rules_breakdown = cyndi_query(rules_breakdown)
+            rules_breakdown = cyndi_join(rules_breakdown)
             rules_breakdown = apply_filters(rules_breakdown, args, [filter_types.SYSTEM_TAGS, filter_types.SYSTEM_SAP, filter_types.SYSTEM_SAP_SIDS], {})
         rules_breakdown = rules_breakdown.first()
 
@@ -172,7 +172,7 @@ class GetDashboard(GetRequest):
                                & (SystemVulnerabilities.mitigation_reason.is_null(True)))
                         .group_by(SystemVulnerabilities.rule_id))
         if cyndi_request:
-            counts_query = cyndi_query(counts_query)
+            counts_query = cyndi_join(counts_query)
             counts_query = apply_filters(counts_query, args, [filter_types.SYSTEM_TAGS, filter_types.SYSTEM_SAP, filter_types.SYSTEM_SAP_SIDS], {})
 
         recent_rules = (InsightsRule.select(InsightsRule.description_text.alias('name'),

--- a/manager/report_handler.py
+++ b/manager/report_handler.py
@@ -8,7 +8,7 @@ from peewee import fn, SQL, JOIN
 
 from common.logging import get_logger
 from common.peewee_model import CveMetadata, CveRuleMapping, InsightsRule, SystemVulnerabilities, SystemPlatform
-from .base import GetRequest, round_to_100_percent, get_system_count, get_account_id, cyndi_query
+from .base import GetRequest, round_to_100_percent, get_system_count, get_account_id, cyndi_join
 
 LOGGER = get_logger(__name__)
 
@@ -97,7 +97,7 @@ class GetExecutive(GetRequest):
                                   (InsightsRule.active == True) & (~InsightsRule.rule_only))))
                        .group_by(SystemVulnerabilities.cve_id)
                        .dicts())
-        count_query = cyndi_query(count_query)
+        count_query = cyndi_join(count_query)
 
         cve_query = (CveMetadata
                      .select(CveMetadata.id.alias("cve_id"),
@@ -183,7 +183,7 @@ class GetExecutive(GetRequest):
                            .group_by(InsightsRule.rule_impact)
                            .dicts())
 
-        rules_breakdown = cyndi_query(rules_breakdown)
+        rules_breakdown = cyndi_join(rules_breakdown)
 
         for section in rules_breakdown:
             retval['rules_by_severity'][section['severity']]['rule_count'] = section['rule_count']
@@ -214,7 +214,7 @@ class GetExecutive(GetRequest):
                      .limit(3)
                      .dicts())
 
-        top_rules = cyndi_query(top_rules)
+        top_rules = cyndi_join(top_rules)
 
         for top_rule in top_rules:
             retval['top_rules'].append(top_rule)

--- a/manager/status_handler.py
+++ b/manager/status_handler.py
@@ -9,7 +9,7 @@ from psycopg2 import IntegrityError as psycopg2IntegrityError
 from common.logging import get_logger
 from common.peewee_model import CveMetadata, DB, SystemPlatform, SystemVulnerabilities, \
     Status, RHAccount, CveAccountData, InsightsRule
-from .base import get_or_create_account, GetRequest, PatchRequest, parse_str_or_list, cyndi_query
+from .base import get_or_create_account, GetRequest, PatchRequest, parse_str_or_list, cyndi_join
 
 LOGGER = get_logger(__name__)
 
@@ -132,7 +132,7 @@ class PatchStatus(PatchRequest):
                                .join(SystemPlatform, on=(SystemVulnerabilities.system_id == SystemPlatform.id))
                                .where(SystemVulnerabilities.id << list(rows_modified))
                                .dicts())
-            updated_details = cyndi_query(updated_details)
+            updated_details = cyndi_join(updated_details)
             updated = []
             for updated_row in updated_details:
                 updated.append({"inventory_id": updated_row["inventory_id"], "cve": updated_row["cve"]})

--- a/manager/system_handler.py
+++ b/manager/system_handler.py
@@ -14,7 +14,7 @@ from common.peewee_model import BusinessRisk, CveAccountData, CveMetadata, Syste
 from common.utils import external_service_request
 from .base import ApplicationException, DEFAULT_BUSINESS_RISK, GetRequest, OS_INFO_QUERY, parse_int_list, PatchRequest, \
     DeleteRequest, CVE_SYNOPSIS_SORT, parse_str_list, parse_str_or_list, reporter, unique_bool_list, parse_tags, \
-    cyndi_query, ServiceAccess, get_advisories_per_cve_from_db, filter_by_advisory, \
+    cyndi_join, ServiceAccess, get_advisories_per_cve_from_db, filter_by_advisory, \
     get_account_id, has_advisory
 from .filters import apply_filters, filter_types
 from .list_view import ListView
@@ -28,7 +28,7 @@ class SystemCvesView(ListView):
 
     def __init__(self, rh_account_id, list_args, query_args, filter_args, parsed_args, uri, ids_only=False, cve_advisories=None):
         query = self._full_query(rh_account_id, query_args) if not ids_only else self._id_query(rh_account_id, query_args)
-        query = cyndi_query(query)
+        query = cyndi_join(query)
         filters = [filter_types.CVE_BUSINESS_RISK,
                    filter_types.CVE_CVSS,
                    filter_types.CVE_IMPACT,
@@ -148,9 +148,9 @@ class SystemView(ListView):
         if list_args["filter"]:  # TODO: refactor to list_view.py/filters.py
             count_subquery = count_subquery.where(SystemPlatform.display_name.contains(list_args["filter"]))
         count_subquery = count_subquery.cte("count_subquery", materialized=True)  # materialize data
-
         query = self._full_query(rh_account_id, count_subquery) if not ids_only else self._id_query(rh_account_id, list_args, count_subquery)
-        query = cyndi_query(query)
+        query = cyndi_join(query)
+
         filters = [filter_types.SYSTEM_STALE,
                    filter_types.SYSTEM_UUID,
                    filter_types.SYSTEM_EXCLUDED]
@@ -522,7 +522,7 @@ class GetSystemDetails(GetRequest):
                      .where(SystemPlatform.inventory_id == inventory_id)
                      .where(RHAccount.name == connexion.context['user'])
                      .where(SystemPlatform.when_deleted.is_null(True)).dicts())
-            system = cyndi_query(query).get()
+            system = cyndi_join(query).get()
         except DoesNotExist as exc:
             raise ApplicationException('inventory_id must exist and inventory_id must be visible to user', 404) from exc
         return {'data': {'last_evaluation': system['last_evaluation'], 'rules_evaluation': system['advisor_evaluated'], 'opt_out': system['opt_out'],

--- a/manager/vulnerabilities_handler.py
+++ b/manager/vulnerabilities_handler.py
@@ -10,7 +10,7 @@ from peewee import Case, fn, JOIN, SQL
 from common.peewee_model import BusinessRisk, CveAccountData, CveMetadata, CveImpact, Status, InsightsRule, CveRuleMapping, SystemVulnerabilities, \
     SystemPlatform
 from .base import DEFAULT_BUSINESS_RISK, DEFAULT_STATUS, GetRequest, parse_int_list, CVE_SYNOPSIS_SORT, get_rules_for_cves, get_system_count, get_account_id, \
-    unique_bool_list, cyndi_query, parse_tags, PostRequest, is_cyndi_request
+    unique_bool_list, cyndi_join, parse_tags, PostRequest, is_cyndi_request
 from .filters import apply_filters, filter_types
 from .list_view import ListView
 
@@ -23,8 +23,9 @@ class CvesListView(ListView):
         if args['affecting'] is None or False in args['affecting'] or True not in args['affecting']:
             join_type = JOIN.LEFT_OUTER
         count_subquery = self._count_subquery(rh_account_id)
+
+        count_subquery = cyndi_join(count_subquery)
         if is_cyndi_request(args):
-            count_subquery = cyndi_query(count_subquery)
             count_subquery = apply_filters(count_subquery, args, [filter_types.SYSTEM_TAGS, filter_types.SYSTEM_SAP, filter_types.SYSTEM_SAP_SIDS], {})
 
         query = self._full_query(rh_account_id, join_type, count_subquery)


### PR DESCRIPTION
Fixes - VULN-{1736, 1726, 1725, 1721}

`cyndi_join` -  normal join, used when we need info from InventoryHosts table.

```
vulnerability=# EXPLAIN ANALYZE select * from system_platform as sp join inventory.hosts as ih on sp.inventory_id = ih.id;
                                                            QUERY PLAN                                                            
----------------------------------------------------------------------------------------------------------------------------------
 Hash Join  (cost=1413.81..6114.97 rows=6436 width=946) (actual time=8.693..33.896 rows=5596 loops=1)
   Hash Cond: (hosts_v1_9.id = sp.inventory_id)
   ->  Seq Scan on hosts_v1_9  (cost=0.00..2536.36 rows=18136 width=336) (actual time=0.010..9.700 rows=18028 loops=1)
   ->  Hash  (cost=842.36..842.36 rows=6436 width=594) (actual time=8.563..8.564 rows=6503 loops=1)
         Buckets: 8192  Batches: 2  Memory Usage: 1888kB
         ->  Seq Scan on system_platform sp  (cost=0.00..842.36 rows=6436 width=594) (actual time=0.007..4.393 rows=6503 loops=1)
 Planning Time: 0.830 ms
 Execution Time: 34.163 ms
(8 rows)
```

`cyndi_in` -  Join using IN keyword, used for consistency checks, like for reports, etc.

 ```
vulnerability=# EXPLAIN ANALYZE select * from system_platform as sp where sp.inventory_id in (select id from inventory.hosts);
                                                                       QUERY PLAN                                                                        
---------------------------------------------------------------------------------------------------------------------------------------------------------
 Hash Join  (cost=1803.03..2662.28 rows=6436 width=594) (actual time=6.647..11.395 rows=5596 loops=1)
   Hash Cond: (sp.inventory_id = hosts_v1_9.id)
   ->  Seq Scan on system_platform sp  (cost=0.00..842.36 rows=6436 width=594) (actual time=0.008..3.029 rows=6503 loops=1)
   ->  Hash  (cost=1576.33..1576.33 rows=18136 width=16) (actual time=6.604..6.605 rows=18028 loops=1)
         Buckets: 32768  Batches: 1  Memory Usage: 1102kB
         ->  Index Only Scan using hosts_v1_9_pkey on hosts_v1_9  (cost=0.29..1576.33 rows=18136 width=16) (actual time=0.004..4.322 rows=18028 loops=1)
               Heap Fetches: 3901
 Planning Time: 0.232 ms
 Execution Time: 11.620 ms
```

From 34 ms to 12 ms, when we do not need data from IH table.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
