### PR TITLE
fix: small clowdapp issues

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -403,9 +403,9 @@ objects:
     - name: manager-admin
       webServices:
         public:
-          enabled: false
-        private:
           enabled: true
+        private:
+          enabled: false
         metrics: {}
       podSpec:
         image: ${IMAGE}:${IMAGE_TAG}
@@ -692,7 +692,7 @@ objects:
   kind: Secret
   metadata:
     name: github-vulnerability-bot
-    namespace: ${ENV_NAME}
+    namespace: test  # namespace is overwritten by bonfire
   type: Opaque
 
 - apiVersion: v1
@@ -709,7 +709,7 @@ objects:
   kind: Secret
   metadata:
     name: vulnerability-db-passwds
-    namespace: ${ENV_NAME}
+    namespace: test  # namespace is overwritten by bonfire
   type: Opaque
 
 - apiVersion: v1
@@ -718,7 +718,7 @@ objects:
   kind: Secret
   metadata:
     name: vulnerability-slack
-    namespace: ${ENV_NAME}
+    namespace: test  # namespace is overwritten by bonfire
   type: Opaque
 
 - apiVersion: v1
@@ -728,7 +728,7 @@ objects:
   kind: Secret
   metadata:
     name: vulnerability-boproxy-token
-    namespace: ${ENV_NAME}
+    namespace: test  # namespace is overwritten by bonfire
   type: Opaque
 
 - apiVersion: v1
@@ -737,7 +737,7 @@ objects:
   kind: Secret
   metadata:
     name: vulnerability-metrics-exclude-accounts
-    namespace: ${ENV_NAME}
+    namespace: test  # namespace is overwritten by bonfire
   type: Opaque
 
 - apiVersion: v1
@@ -747,7 +747,7 @@ objects:
   kind: Secret
   metadata:
     name: kafka-credentials
-    namespace: ${ENV_NAME}
+    namespace: test  # namespace is overwritten by bonfire
   type: Opaque
 
 - apiVersion: v1
@@ -756,7 +756,7 @@ objects:
   kind: Secret
   metadata:
     name: kafka-ca
-    namespace: ${ENV_NAME}
+    namespace: test  # namespace is overwritten by bonfire
   type: Opaque
 
 parameters:
@@ -912,9 +912,6 @@ parameters:
 - name: MANIFEST_BRANCH
   description: Git branch for manifests
   value: master
-- name: PATCH_HOST
-  description: URL of PATCH service.
-  value: ""
 - name: PATCH_ADVISORIES_API
   description: Path to PATCH advisories endpoint.
   value: /api/patch/v1/advisories


### PR DESCRIPTION
-  Bonfire can't deploy app if `namespace: ${ENV_NAME}` is set for secret
- define manager-admin url as public, so we can get it in tests (afaik it doesn't mean that it will have exposed route)
- remove unnecessary PATCH_HOST env var

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
