### PR TITLE
fix clowder deployment

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -674,7 +674,7 @@ objects:
     dependencies:
     - host-inventory
     - ingress
-    - engine
+    # - insights-engine
     - vmaas
     # optionalDependencies:
     # - patchman-engine  # not using Clowder yet

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,7 +15,7 @@ if [[ ! -z $1 ]]; then
     elif [[ "$1" == "manager-dev" ]]; then
         exec gunicorn --reload -c manager/gunicorn_conf.py -w ${GUNICORN_WORKERS:-4} --bind=0.0.0.0:8000 --timeout=60 manager.main
     elif [[ "$1" == "manager-admin" ]]; then
-        port=$(python3 -c "import app_common_python as a;print(a.LoadedConfig.privatePort or 8000)")
+        port=$(python3 -c "import app_common_python as a;print(a.LoadedConfig.publicPort or 8000)")
         exec gunicorn -c manager/gunicorn_conf.py -w ${GUNICORN_WORKERS:-4} --bind=0.0.0.0:${port} --timeout=60 manager.admin
     elif [[ "$1" == "advisor-listener" ]]; then
         exec python3 -m advisor_listener.advisor_listener


### PR DESCRIPTION
- manager-admin had wrong port - I forget to change it to publicPort in my previous PR
- insights-engine can't be deployed because ci-ext jenkins couldn't access gitlab, thus disable it for now. I asked in #forum-clouddot how we should handle this case

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
