### PR TITLE
fix(clowder): taskomatic and vmaas_sync are private endpoints

### DIFF
--- a/common/config.py
+++ b/common/config.py
@@ -191,11 +191,6 @@ class Config(BaseConfig, metaclass=Singleton):
         for endpoint in cfg.endpoints:
             if endpoint.app == "rbac":
                 self.rbac_url = f"http://{endpoint.hostname}:{endpoint.port}"
-            elif endpoint.app == "vulnerability":
-                if "taskomatic" in endpoint.name:
-                    self.taskomatic_host = f"http://{endpoint.hostname}:{endpoint.port}"
-                elif "vmaas-sync" in endpoint.name:
-                    self.vmaas_sync_host = f"http://{endpoint.hostname}:{endpoint.port}"
             elif endpoint.app == "vmaas":
                 if "webapp" in endpoint.name:
                     self.vmaas_host = f"http://{endpoint.hostname}:{endpoint.port}"
@@ -204,6 +199,12 @@ class Config(BaseConfig, metaclass=Singleton):
         for endpoint in cfg.privateEndpoints:
             if endpoint.app == "vmaas" and "websocket" in endpoint.name:
                 self.vmaas_websocket_host = f"{endpoint.hostname}:{endpoint.port}"
+            elif endpoint.app == "vulnerability-engine":
+                if "taskomatic" in endpoint.name:
+                    self.taskomatic_host = f"http://{endpoint.hostname}:{endpoint.port}"
+                elif "vmaas-sync" in endpoint.name:
+                    self.vmaas_sync_host = f"http://{endpoint.hostname}:{endpoint.port}"
+
         # TODO: Back office proxy (mocked) needs to be deployed to ephemeral too
         # when we are in ephemeral, we may want obtain bo_proxy url from app_common_python
         # otherwise (even in Prod?) we may want to use an env variable

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -16,7 +16,7 @@ objects:
         public:
           enabled: false
         private:
-          enabled: true
+          enabled: false
         metrics: {}
       podSpec:
         image: ${IMAGE}:${IMAGE_TAG}


### PR DESCRIPTION
- fix getting hostname:port for private endpoints
- advisor-listener does not need opened port

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
