### PR TITLE
fix(database): run migrations as single transactions and detect errors better

### DIFF
--- a/database/schema/upgrade_scripts/078-system-platform-uuid.sql
+++ b/database/schema/upgrade_scripts/078-system-platform-uuid.sql
@@ -40,8 +40,6 @@ BEGIN
     low = low + batch_size;
     high = high + batch_size;
     max_ = (SELECT last_value FROM system_platform_id_seq);
-
-    COMMIT;
   END LOOP;
 END; $$;
 

--- a/database/upgrade/upgrade.py
+++ b/database/upgrade/upgrade.py
@@ -152,14 +152,16 @@ class DatabaseUpgrade:
                                '-p', str(DatabasePoolHandler.db_port),
                                '-U', DatabasePoolHandler.db_user,
                                '-d', DatabasePoolHandler.db_name,
-                               '-f', self.scripts_dir + script_file],
+                               '-f', self.scripts_dir + script_file,
+                               '--single-transaction',
+                               '-v', 'ON_ERROR_STOP=on'],
                               stdout=subprocess.PIPE,
                               stderr=subprocess.PIPE,
                               universal_newlines=True,
                               env=psql_env,
                               check=False)
 
-        if psql.returncode != 0 or psql.stderr:
+        if psql.returncode != 0:
             status = 'failed'
             failure = True
             LOGGER.error('upgrade failure')


### PR DESCRIPTION
For example `TRUNCATE ... CASCADE` command produces notices which are printed to stderr by psql, and such migrations are marked as failed.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
