### PR TITLE
VULN-1523 refactor(vmaas_sync): reevaluate systems by rh_account_id

### DIFF
--- a/vmaas_sync/vmaas_sync.py
+++ b/vmaas_sync/vmaas_sync.py
@@ -45,14 +45,14 @@ class BaseView(web.View):
             cur.execute("""select inventory_id from system_platform where
                            when_deleted is null and
                            id in (select distinct system_id from system_repo where repo_id in
-                           (select id from repo where name in %s))""", (tuple(repos),))
+                           (select id from repo where name in %s)) order by rh_account_id""", (tuple(repos),))
         else:
             cur.execute("""select * from system_repo where (1=0)""")  # ensure empty result
 
     @classmethod
     def select_all_inventory_ids(cls, cur):
         """Select all inventory-ids, don't fetch it."""
-        cur.execute("select inventory_id from system_platform where when_deleted is null")
+        cur.execute("select inventory_id from system_platform where when_deleted is null order by rh_account_id")
 
     @classmethod
     def get_last_repobased_eval_tms(cls, cur):
@@ -413,19 +413,19 @@ class VmaasSyncContext:
     async def start(self, _):
         """Start websocket server."""
         # Sync CVEs always when app starts
-        self.evaluator_queue = mqueue.MQWriter(CFG.evaluator_upload_topic)
+        VmaasSyncContext.evaluator_queue = mqueue.MQWriter(CFG.evaluator_upload_topic)
         SyncHandler.sync_cve_md()
         SyncHandler.sync_exploits()
-        self.websocket_task = asyncio.ensure_future(self._websocket_loop())
+        VmaasSyncContext.websocket_task = asyncio.ensure_future(self._websocket_loop())
 
     async def stop(self, _):
         """Stop websocket server."""
         await self.evaluator_queue.stop()
 
-        if self.websocket_task is not None or not self.websocket_task.done():
+        if self.websocket_task is not None and not self.websocket_task.done():
             self.websocket_task.cancel()
 
-        if self.vmaas_websocket is not None or not self.vmaas_websocket.closed:
+        if self.vmaas_websocket is not None and not self.vmaas_websocket.closed:
             await self.vmaas_websocket.close()
             self.vmaas_websocket = None
             LOGGER.info("Websocket connection closed.")


### PR DESCRIPTION
Tested this on local CI copy of vmaas and engine db. I compared evaluations for all systems. The sorted evaluation was like few MB lighter, but like 30 seconds faster.

Reevaluation of 9000 systems:
Non-sorted evaluation was like 3:40 - 4:00 minutes long
Sorted evaluation was something 2:35 - 3:10 minutes long 

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
