### PR TITLE
fix(vmaas_sync): make every sync threaded

### DIFF
--- a/tests/vmaas_sync_tests/test_vmaas_sync.py
+++ b/tests/vmaas_sync_tests/test_vmaas_sync.py
@@ -169,7 +169,6 @@ class TestVmaasSync:
         self.check_sync_exploits_logs(caplog.records, 4)
         self.check_re_evaluate_all_logs(caplog.records, 6)
         caplog.clear()
-        await srvapp.session.close()
 
     async def test_bogus_message(self, monkeypatch, caplog):
         """Test getting EMPTY and UNRECOGNIZED msg from mqueue"""

--- a/vmaas_sync/vmaas_sync.py
+++ b/vmaas_sync/vmaas_sync.py
@@ -279,7 +279,7 @@ class SyncHandler(BaseView):
     @staticmethod
     async def a_sync_cve_md():
         """async wrapper for sync_cve_md and sync_exploits"""
-        with await SYNC_LOCK:
+        async with SYNC_LOCK:
             loop = asyncio.get_event_loop()
             await loop.run_in_executor(None, SyncHandler.sync_cve_md)
             await loop.run_in_executor(None, SyncHandler.sync_exploits)
@@ -408,14 +408,13 @@ class VmaasSyncContext:
 
         self.instance = asyncio.get_event_loop()
         self.vmaas_websocket_url = f"ws://{CFG.vmaas_websocket_host}/"
-        self.session = ClientSession()
 
     async def start(self, _):
         """Start websocket server."""
         # Sync CVEs always when app starts
         VmaasSyncContext.evaluator_queue = mqueue.MQWriter(CFG.evaluator_upload_topic)
-        SyncHandler.sync_cve_md()
-        SyncHandler.sync_exploits()
+        VmaasSyncContext.session = ClientSession()
+        await SyncHandler.a_sync_cve_md()
         VmaasSyncContext.websocket_task = asyncio.ensure_future(self._websocket_loop())
 
     async def stop(self, _):
@@ -458,8 +457,7 @@ class VmaasSyncContext:
                 if msg.type == WSMsgType.TEXT and msg.data == "webapps-refreshed":
                     REFRESH.inc()
                     LOGGER.info("VMaaS cache refreshed")
-                    SyncHandler.sync_cve_md()
-                    SyncHandler.sync_exploits()
+                    await SyncHandler.a_sync_cve_md()
                     if CFG.enable_re_evaluation:
                         asyncio.ensure_future(ReEvaluateHandler.re_evaluate_systems(CFG.enable_repo_based_re_evaluation))
                     else:


### PR DESCRIPTION
Previously syncs were blocking readiness and liveness probes, which caused restart or event fails in openshift.
The session and async with changes are just removing deprecated warnings.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
