### PR TITLE
fix(clowder): add rbac as dependency

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -657,6 +657,7 @@ objects:
     - ingress
     - engine
     - vmaas
+    - rbac
     # optionalDependencies:
     # - patchman-engine  # not using Clowder yet
     database:


### PR DESCRIPTION
We cannot access rbac url if it is not set as dependency. It results in
running app without querying RBAC.

VULN-1866

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
