### PR TITLE
chore(clowder): add resources specification for metrics

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -658,6 +658,13 @@ objects:
             secretKeyRef:
               key: x_rh_apitoken
               name: vulnerability-boproxy-token
+        resources:
+          limits:
+            cpu: ${{CPU_LIMIT_METRICS}}
+            memory: ${{MEMORY_LIMIT_METRICS}}
+          requests:
+            cpu: ${{CPU_REQUEST_METRICS}}
+            memory: ${{MEMORY_REQUEST_METRICS}}
 
 
 
@@ -878,6 +885,18 @@ parameters:
   description: Requested memory for pod
   value: "512Mi"
 - name: MEMORY_LIMIT_VMAAS_SYNC
+  description: Maximum memory limit for pod
+  value: "512Mi"
+- name: CPU_REQUEST_METRICS
+  description: Requested CPU limit for pod
+  value: 100m
+- name: CPU_LIMIT_METRICS
+  description: Maximum CPU limit for pod
+  value: 300m
+- name: MEMORY_REQUEST_METRICS
+  description: "Requested memory for pod"
+  value: "512Mi"
+- name: MEMORY_LIMIT_METRICS
   description: Maximum memory limit for pod
   value: "512Mi"
 - name: LOGGING_LEVEL_APP


### PR DESCRIPTION
VULN-1827

Without the specification in Stage, metrics requested only 30M, which was not enough to even run the container.
```
(combined from similar events): Error creating: pods "vulnerability-engine-metrics-27126793-c26sr" is forbidden: [minimum cpu usage per Container is 50m, but request is 30m, minimum cpu usage per Pod is 50m, but request is 30m]
```

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
