### PR TITLE
fix(clowder): add missing env vars to clowdapp

### DIFF
--- a/common/config.py
+++ b/common/config.py
@@ -51,7 +51,7 @@ class BaseConfig:
         self.kafka_group_id = os.getenv("KAFKA_GROUP_ID", "vulnerability")
 
         self.vmaas_vulnerabilities_api = os.getenv("VMAAS_VULNERABILITIES_API", "/api/v1/vulnerabilities")
-        self.vmaas_oval_enable = strtobool(os.getenv('VMAAS_OVAL_ENABLE', 'TRUE'))
+        self.vmaas_oval_enable = strtobool(os.getenv('VMAAS_OVAL_ENABLE', 'FALSE'))
 
         self.evaluator_prometheus_port = 8085
         self.taskomatic_prometheus_port = 8085

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -134,6 +134,10 @@ objects:
               key: password
               name: kafka-credentials
               optional: true
+        - name: DB_MAX_POOL_SIZE
+          value: ${DB_MAX_POOL_SIZE}
+        - name: DB_MIN_POOL_SIZE
+          value: ${DB_MIN_POOL_SIZE}
         volumes:
         - name: kafka-cacert
           secret:
@@ -202,6 +206,12 @@ objects:
               key: password
               name: kafka-credentials
               optional: true
+        - name: DB_MAX_POOL_SIZE
+          value: ${DB_MAX_POOL_SIZE}
+        - name: DB_MIN_POOL_SIZE
+          value: ${DB_MIN_POOL_SIZE}
+        - name: VMAAS_OVAL_ENABLE
+          value: ${VMAAS_OVAL_ENABLE}
         volumes:
         - name: kafka-cacert
           secret:
@@ -391,6 +401,8 @@ objects:
           value: ${PATCH_HOST}
         - name: DISABLE_ACCOUNT_CACHE
           value: ${DISABLE_ACCOUNT_CACHE}
+        - name: DEFAULT_PAGE_SIZE
+          value: '5000'
         resources:
           limits:
             cpu: ${{CPU_LIMIT_MANAGER}}
@@ -504,6 +516,8 @@ objects:
             secretKeyRef:
               key: exclude_accounts
               name: vulnerability-metrics-exclude-accounts
+        - name: CACHE_MINIMAL_ACCOUNT_SYSTEMS
+          value: ${CACHE_MINIMAL_ACCOUNT_SYSTEMS}
         resources:
           limits:
             cpu: ${{CPU_LIMIT_TASKOMATIC}}
@@ -902,4 +916,12 @@ parameters:
   value: ""
 - name: DISABLE_ACCOUNT_CACHE
   description: Disable caching in manager for accounts
+  value: "FALSE"
+- name: CACHE_MINIMAL_ACCOUNT_SYSTEMS
+  value: '1000'
+- name: DB_MAX_POOL_SIZE
+  value: '30'
+- name: DB_MIN_POOL_SIZE
+  value: '10'
+- name: VMAAS_OVAL_ENABLE
   value: "FALSE"


### PR DESCRIPTION
list of all missing env vars based on the following script
```bash
#!/bin/bash
VARS_CODE=$(git grep -oP "(getenv\([\"']|environ\[[\"']|environ\.get\([\"'])\K[\w\d]+" | cut -d ':' -f2 | sort -u)
for var in $VARS_CODE; do
    grep -q $var deploy/clowdapp.yaml
    [ "$?" -ne "0" ] && missing="$missing\n$var"
done
echo -e $missing
```
```
AWS_REGION
CACHE_MINIMAL_ACCOUNT_SYSTEMS
CW_AWS_ACCESS_KEY_ID
CW_AWS_SECRET_ACCESS_KEY
CW_LOG_GROUP
DB_MAX_POOL_SIZE
DB_MIN_POOL_SIZE
DEBUG
DEFAULT_PAGE_SIZE
EMAIL_FROM
EMAIL_MONTHLY_TO
EMAIL_PARTIAL_MONTH_TO
EXCLUDE_ACCOUNTS
HOME
HOSTNAME
HTTP_REFERER
HTTP_USER_AGENT
KAFKA_GROUP_ID
KAFKA_HOST
KAFKA_PORT
MINIMAL_SCHEMA
PATH_INFO
PAYLOAD_TRACKER_TOPIC
POSTGRESQL_DATABASE
POSTGRESQL_HOST
POSTGRESQL_PORT
POSTGRESQL_SSL_MODE
POSTGRESQL_SSL_ROOT_CERT_PATH
prometheus_multiproc_dir
PROMETHEUS_PORT
QUERY_STRING
RAW_URI
RBAC_URL
REMEDIATION_UPDATES_TOPIC
REMOTE_ADDR
REQUEST_METHOD
SERVER_PROTOCOL
SMTP_HOST
SMTP_PASS
SMTP_USER
STATUS_TIMEOUT
TASKOMATIC_HOST
UPGRADE_FROM
UPGRADE_TO
VE_DB_USER_ADVISOR_LISTENER_PASSWORD
VE_DB_USER_EVALUATOR_PASSWORD
VE_DB_USER_LISTENER_PASSWORD
VE_DB_USER_MANAGER_PASSWORD
VE_DB_USER_METRICS_PASSWORD
VE_DB_USER_TASKOMATIC_PASSWORD
VE_DB_USER_VMAAS_SYNC_PASSWORD
VMAAS_HOST
VMAAS_OVAL_ENABLE
VMAAS_SYNC_HOST
VMAAS_WEBSOCKET_HOST
```

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
