### PR TITLE
chore(clowder): add legacy port for manager

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -309,7 +309,7 @@ objects:
             cpu: ${{CPU_REQUEST_LISTENER}}
             memory: ${{MEMORY_REQUEST_LISTENER}}
 
-    - name: manager
+    - name: manager-service
       webServices:
         public:
           enabled: true
@@ -711,6 +711,27 @@ objects:
     name: kafka-ca
     namespace: test  # namespace is overwritten by bonfire
   type: Opaque
+
+# proxy requests for old service for smooth transition
+# vulnerability-engine-manager:8443 to the clowderized one - vulnerability-engine-manager-service:8000
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: vulnerability-engine-manager
+    labels:
+      app: vulnerability-engine-manager
+  spec:
+    ports:
+    - port: 8443
+      protocol: TCP
+      targetPort: 8000
+      name: weblegacy
+    - port: 8000
+      protocol: TCP
+      targetPort: 8000
+      name: clowderlegacy
+    selector:
+      pod: vulnerability-engine-manager-service
 
 parameters:
 - description: Image tag


### PR DESCRIPTION
VULN-1909

in case anyone is calling vulnerability-engine-manager from inside the cluster (remediation had issues when we made a change in stage)
## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
