### PR TITLE
chore: use boproxy token from ephemeral-base

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -559,16 +559,6 @@ objects:
 
 - apiVersion: v1
   data:
-    ca_cert: ""
-    x_rh_apitoken: ""
-  kind: Secret
-  metadata:
-    name: vulnerability-boproxy-token
-    namespace: test  # namespace is overwritten by bonfire
-  type: Opaque
-
-- apiVersion: v1
-  data:
     exclude_accounts: ""
   kind: Secret
   metadata:


### PR DESCRIPTION
boproxy token secret is present in app-interface ephemeral-base and we should not overwrite it with the empty value from clowdapp.yaml

maybe it would be needed to delete old secrets from all ephemeral namespaces once this is merged
## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
