### PR TITLE
chore(prcheck): run tests only for 'core' requirements

### DIFF
--- a/pr_check.sh
+++ b/pr_check.sh
@@ -11,9 +11,9 @@ CACHE_FROM_LATEST_IMAGE="true"
 
 export IQE_PLUGINS="vulnerability"
 export IQE_MARKER_EXPRESSION="smoke and api"
-export IQE_FILTER_EXPRESSION=""
-export IQE_REQUIREMENTS_PRIORITY=""
-export IQE_TEST_IMPORTANCE=""
+export IQE_FILTER_EXPRESSION="not edge"
+export IQE_REQUIREMENTS_PRIORITY="critical,high"
+export IQE_TEST_IMPORTANCE="critical,high"
 export IQE_CJI_TIMEOUT="60m"
 export DEPLOY_TIMEOUT=900
 


### PR DESCRIPTION
prcheck is killed because it takes more than 1h which is the limit for namespace reservation, let's try to limit executed tests only to test 'core' functionality -> critical and high requirements priority and critical and high test importance

last pr-check took:
- 16 min deploy
- 1 min until iqe ran tests
- 9 min vmaas sync
- 96% of tests ran and then it was killed

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
