### PR TITLE
fix(notificator): advisor evaluation should have first priority

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip pipenv codecov importlib-resources==1.5.0
-          cd tests && pipenv install --ignore-pipfile --deploy --system && if [ "${PIPENV_CHECK}" == "1" ] ; then pipenv check --system ; fi && cd ..
+          cd tests && pipenv install --ignore-pipfile --deploy --system && if [ "${PIPENV_CHECK}" == "1" ] ; then pipenv check --system -i 45185 ; fi && cd ..
       - name: Install PostgreSQL 12
         run: |
           sudo apt-get update

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -21,7 +21,7 @@ ENV LANG=en_US.utf8
 ARG PIPENV_CHECK=1
 ARG PIPENV_PYUP_API_KEY=""
 RUN pipenv install --ignore-pipfile --deploy && ln -s /usr/bin/python3 /usr/bin/python && \
-    if [ "${PIPENV_CHECK}" == 1 ] ; then pipenv check --system ; fi
+    if [ "${PIPENV_CHECK}" == 1 ] ; then pipenv check --system -i 45185 ; fi
 
 ADD . /engine
 

--- a/notificator/notificator_queue.py
+++ b/notificator/notificator_queue.py
@@ -2,7 +2,7 @@
 NotificatorQueue, processes potential notifications from queues.
 """
 import asyncio
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 import asyncpg
 
 from common import mqueue
@@ -12,7 +12,7 @@ from common.peewee_model import NotificationType
 
 CFG = Config()
 LOGGER = get_logger(__name__)
-ADVISOR_EVALUATOR_MAX_DIFF = 10 * 60  # 10 minutes
+EVALUATION_WAIT_MINUTES = 5
 
 
 class QueueItem:
@@ -149,12 +149,17 @@ class NotificatorQueue:
 
     @staticmethod
     def _is_fully_evaluated(sys_vuln_row):
-        """Check if sys vuln was evaluated by evaluator and advisor, also
-           the difference between the timestamps that they were evaluated,
-           must be less than 10 minutes (to ensure it is not new evaluation and old advisor result)"""
-        return (sys_vuln_row[0] is not None and
-                sys_vuln_row[1] is not None and
-                abs((sys_vuln_row[0] - sys_vuln_row[1]).total_seconds()) <= ADVISOR_EVALUATOR_MAX_DIFF)
+        """Check if sys vuln was evaluated by evaluator and advisor."""
+        # if both are set, count it as evaluated
+        if sys_vuln_row[0] is not None and sys_vuln_row[1] is not None:
+            return True
+        evaluated_threshold = datetime.now(timezone.utc) - timedelta(minutes=EVALUATION_WAIT_MINUTES)
+        # give 5 minutes, to wait for second component or count it as evaluated
+        if sys_vuln_row[1] is not None:
+            return sys_vuln_row[1] < evaluated_threshold
+        if sys_vuln_row[0] is not None:
+            return sys_vuln_row[0] < evaluated_threshold
+        return False
 
     @staticmethod
     def _is_not_mitigated(sys_vuln_row):


### PR DESCRIPTION
Vulnerabilities detected by advisor only (and not evaluator) got stuck in the queue, because currently we check for both evaluations to be done. Lets only check for advisor evaluation, this causes that.

Vulnerability by evaluator -> needs to wait for advisor evaluation
Vulnerability by advisor -> does not need to wait for evaluator

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
