### PR TITLE
perf: fetch all rows at once instead of using cursor

### DIFF
--- a/advisor_listener/advisor_listener.py
+++ b/advisor_listener/advisor_listener.py
@@ -93,7 +93,7 @@ async def db_import_cve(cve: str, conn: Connection):
         async with conn.transaction():
             if success:
                 impact_id_map = {}
-                async for row in conn.cursor("SELECT name, id FROM cve_impact"):
+                for row in await conn.fetch("SELECT name, id FROM cve_impact"):
                     impact_name, impact_id = row
                     impact_id_map[impact_name] = impact_id
 
@@ -167,7 +167,7 @@ async def db_import_rule_hits(conn: Connection, rh_account_id: int, acc_num: str
 
     active_rules = set()
     rules_playbook_count = {}
-    async for row in conn.cursor("""SELECT ir.id, ir.playbook_count, ir.active FROM insights_rule ir"""):
+    for row in await conn.fetch("""SELECT ir.id, ir.playbook_count, ir.active FROM insights_rule ir"""):
         rule_id, rule_playbook_count, rule_active = row
         rules_playbook_count[rule_id] = rule_playbook_count
         if rule_active:
@@ -182,11 +182,11 @@ async def db_import_rule_hits(conn: Connection, rh_account_id: int, acc_num: str
     mit_sys_vulns = []
     unmit_sys_vulns = []
 
-    async for row in conn.cursor("""SELECT sv.id, sv.cve_id, sv.rule_id, sv.when_mitigated, sv.rule_hit_details,
-                                           sv.mitigation_reason, sv.advisory_available, cm.cve
-                                    FROM system_vulnerabilities sv
-                                    JOIN cve_metadata cm ON sv.cve_id = cm.id
-                                    WHERE system_id = $1 AND rh_account_id = $2""", system_id, rh_account_id):
+    for row in await conn.fetch("""SELECT sv.id, sv.cve_id, sv.rule_id, sv.when_mitigated, sv.rule_hit_details,
+                                          sv.mitigation_reason, sv.advisory_available, cm.cve
+                                   FROM system_vulnerabilities sv
+                                   JOIN cve_metadata cm ON sv.cve_id = cm.id
+                                   WHERE system_id = $1 AND rh_account_id = $2""", system_id, rh_account_id):
         row_id, cve_id, rule_id, when_mitigated, rule_hit_details_db, mitigation_reason_db, advisory_available, cve = row
         playbook_count = rules_playbook_count.get(rule_hits.get(cve_id, {}).get('id'))
         mitigation_reason = rule_hits.get(cve_id, {}).get('mitigation_reason')
@@ -328,10 +328,10 @@ async def db_init_caches():
     async with DB_POOL.acquire() as conn:
         async with conn.transaction():
             try:
-                async for row in conn.cursor("""SELECT id, name FROM insights_rule"""):
+                for row in await conn.fetch("""SELECT id, name FROM insights_rule"""):
                     rule_db_id, rule_name = row
                     RULES_CACHE[rule_name] = rule_db_id
-                async for row in conn.cursor("""SELECT id, cve FROM cve_metadata"""):
+                for row in await conn.fetch("""SELECT id, cve FROM cve_metadata"""):
                     cve_id, cve_name = row
                     CVES_CACHE[cve_name] = cve_id
             # pylint: disable=broad-except

--- a/evaluator/evaluator.py
+++ b/evaluator/evaluator.py
@@ -47,11 +47,11 @@ MAX_MESSAGES_SEMAPHORE = asyncio.BoundedSemaphore(CFG.max_loaded_evaluator_msgs)
 
 async def _load_cves_for_inventory_id(rh_account_id, system_id, conn):
     system_cves_map = {}
-    async for record in conn.cursor("""select cm.id, cm.cve, sv.id as sv_id, sv.when_mitigated, sv.mitigation_reason, ir.active, ir.playbook_count
-                                         from system_vulnerabilities sv
-                                         join cve_metadata cm on sv.cve_id = cm.id
-                                         left outer join insights_rule ir on sv.rule_id = ir.id
-                                        where sv.system_id = $1 and sv.rh_account_id = $2""", system_id, rh_account_id):
+    for record in await conn.fetch("""select cm.id, cm.cve, sv.id as sv_id, sv.when_mitigated, sv.mitigation_reason, ir.active, ir.playbook_count
+                                        from system_vulnerabilities sv
+                                        join cve_metadata cm on sv.cve_id = cm.id
+                                        left outer join insights_rule ir on sv.rule_id = ir.id
+                                       where sv.system_id = $1 and sv.rh_account_id = $2""", system_id, rh_account_id):
         system_cves_map[record['cve']] = {'sv_id': record['sv_id'],
                                           'cve_id': record['id'],
                                           'when_mitigated': record['when_mitigated'],
@@ -85,9 +85,9 @@ async def _store_new_cves(rh_account_id, system_id, new_cves, conn):
     cve_to_advisory = {new_cve[0]: new_cve[1] for new_cve in new_cves}
     cve_id_to_advisory = {}
 
-    async for record in conn.cursor("""select id, cve
-                                         from cve_metadata
-                                        where cve = any($1::text[])""", list(cve_to_advisory.keys())):
+    for record in await conn.fetch("""select id, cve
+                                      from cve_metadata
+                                      where cve = any($1::text[])""", list(cve_to_advisory.keys())):
         new_cves_ids.add(record['id'])
         cves_in_db.add(record['cve'])
         cve_id_to_advisory[record['id']] = cve_to_advisory[record['cve']]

--- a/notificator/notificator.py
+++ b/notificator/notificator.py
@@ -37,7 +37,7 @@ class NotificatorConditions:
         res = {}
         async with self.db_pool.acquire() as conn:
             async with conn.transaction():
-                cur = conn.cursor("""SELECT DISTINCT(cm.id), cm.cve, COALESCE(cm.cvss2_score, cm.cvss3_score, 0.0) AS cvss_score,
+                rows = await conn.fetch("""SELECT DISTINCT(cm.id), cm.cve, COALESCE(cm.cvss2_score, cm.cvss3_score, 0.0) AS cvss_score,
                                                   cm.impact_id, cm.exploits,
                                                   CASE WHEN cm.id IN (SELECT cve_id FROM cve_rule_mapping AS crm
                                                                       JOIN insights_rule AS ir ON crm.rule_id = ir.id
@@ -45,7 +45,7 @@ class NotificatorConditions:
                                                   cm.public_date
                                            FROM cve_metadata AS cm
                                            WHERE cm.public_date IS NOT NULL""")
-                async for cve_row in cur:
+                for cve_row in rows:
                     cve = {}
                     cve["cve"] = cve_row[1]
                     cve["cvss_score"] = cve_row[2]

--- a/notificator/notificator_queue.py
+++ b/notificator/notificator_queue.py
@@ -53,8 +53,8 @@ class NotificatorQueue:
         res = {}
         async with self.db_pool.acquire() as conn:
             async with conn.transaction():
-                cur = conn.cursor("""SELECT rh_account_id, cve_id, notif_type FROM notified_accounts""")
-                async for notif_row in cur:
+                rows = await conn.fetch("""SELECT rh_account_id, cve_id, notif_type FROM notified_accounts""")
+                for notif_row in rows:
                     rh_acc = notif_row[0]
                     cve_id = notif_row[1]
                     notif_type = NotificationType(notif_row[2])
@@ -73,8 +73,8 @@ class NotificatorQueue:
         new_events = set()
         async with self.db_pool.acquire() as conn:
             async with conn.transaction():
-                cur = conn.cursor("""SELECT notif_type FROM notified_accounts WHERE cve_id = $1 AND rh_account_id = $2""", cve_id, rh_account_id)
-                async for notif_row in cur:
+                rows = await conn.fetch("""SELECT notif_type FROM notified_accounts WHERE cve_id = $1 AND rh_account_id = $2""", cve_id, rh_account_id)
+                for notif_row in rows:
                     new_events.add(NotificationType(notif_row[0]))
         if new_events:
             self.notified_accounts[(rh_account_id, cve_id)] = new_events


### PR DESCRIPTION
default prefetch is 50, resulting in multiple queries

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
