### PR TITLE
fix(vmaas_sync): fix semaphore init

### DIFF
--- a/tests/vmaas_sync_tests/test_vmaas_sync.py
+++ b/tests/vmaas_sync_tests/test_vmaas_sync.py
@@ -120,6 +120,7 @@ class TestVmaasSync:
     async def test_re_evaluate_all(self, pg_db_conn, monkeypatch, caplog):  # pylint: disable=unused-argument
         """Test re_evaluate_systems - all-systems mode"""
         VmaasSyncContext.evaluator_queue = TestMqueueWriter()
+        VmaasSyncContext.batch_semaphore = asyncio.BoundedSemaphore(1)
         future = asyncio.Future()
         future.set_result(True)
         monkeypatch.setattr(VmaasSyncContext, '_websocket_reconnect', lambda self: future)

--- a/vmaas_sync/vmaas_sync.py
+++ b/vmaas_sync/vmaas_sync.py
@@ -28,9 +28,6 @@ REFRESH = Counter('ve_vmaas_sync_webscan_refreshes', '# of times VMaaS told us i
 CNX_FAIL = Counter('ve_vmaas_sync_websocket_failures', '# of times VMaaS websocket closed on us')
 CNX_RECONNECT = Counter('ve_vmaas_sync_websocket_recnx', '# of times attempted VMaaS websocket reconnect')
 
-# how many batches to create at the same time
-RE_EVALUATION_KAFKA_BATCH_SEMAPHORE = asyncio.BoundedSemaphore(CFG.re_evaluation_kafka_batches)
-
 SYNC_LOCK = asyncio.Lock()
 
 
@@ -270,16 +267,16 @@ class ReEvaluateHandler(BaseView):
                     cls.select_all_inventory_ids(cur)
                 total_scheduled = 0
                 while True:
-                    await RE_EVALUATION_KAFKA_BATCH_SEMAPHORE.acquire()
+                    await VmaasSyncContext.batch_semaphore.acquire()
                     rows = cur.fetchmany(size=CFG.re_evaluation_kafka_batch_size)
                     if not rows:
-                        RE_EVALUATION_KAFKA_BATCH_SEMAPHORE.release()
+                        VmaasSyncContext.batch_semaphore.release()
                         break
                     msgs = [{"type": "re-evaluate_system", "host": {"id": inventory_id, "account": account_number, "org_id": org_id}}
                             for inventory_id, account_number, org_id in rows]
                     total_scheduled += len(msgs)
                     future = VmaasSyncContext.evaluator_queue.send_list(msgs)
-                    future.add_done_callback(lambda x: RE_EVALUATION_KAFKA_BATCH_SEMAPHORE.release())
+                    future.add_done_callback(lambda x: VmaasSyncContext.batch_semaphore.release())
                 LOGGER.info("%s systems scheduled for re-evaluation", total_scheduled)
             conn.commit()
 
@@ -355,6 +352,7 @@ class VmaasSyncContext:
     instance = None
     session = None
     websocket_task = None
+    batch_semaphore = None
 
     def __init__(self):
         self.app = web.Application(logger=LOGGER)
@@ -374,9 +372,10 @@ class VmaasSyncContext:
 
     async def start(self, _):
         """Start websocket server."""
-        # Sync CVEs always when app starts
+        VmaasSyncContext.batch_semaphore = asyncio.BoundedSemaphore(CFG.re_evaluation_kafka_batches)
         VmaasSyncContext.evaluator_queue = mqueue.MQWriter(CFG.evaluator_recalc_topic)
         VmaasSyncContext.session = ClientSession()
+        # Sync CVEs always when app starts
         if CFG.sync_on_start:
             await SyncHandler.a_sync_cve_md()
         VmaasSyncContext.websocket_task = asyncio.ensure_future(self._websocket_loop())
@@ -463,7 +462,7 @@ def main():
         for sig in signals:
             signal.signal(sig, terminate)
 
-        web.run_app(app_cont.app, port=CFG.private_port)
+        web.run_app(app_cont.app, port=CFG.private_port, loop=loop)
 
     LOGGER.info("Shutting down.")
 


### PR DESCRIPTION
This is most likely the issue because the AioHTTP server runs in the same loop as the websocket .

https://stackoverflow.com/questions/55918048/asyncio-semaphore-runtimeerror-task-got-future-attached-to-a-different-loop

VULN-2393

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
