### PR TITLE
perf(dashboard): reuse affected cves from overall cves query

### DIFF
--- a/manager/dashboard_handler.py
+++ b/manager/dashboard_handler.py
@@ -115,7 +115,11 @@ class GetDashboard(GetRequest):
                  .join(active_cves_subquery, on=(CveMetadata.id == active_cves_subquery.c.cve_id_))
                  .dicts())
 
-        cve_data = [(cve["cvss_score"], cve["public_date"], cve["exploits"]) for cve in query]
+        cve_data = []
+        affecting_cves = []
+        for cve in query:
+            cve_data.append((cve["cvss_score"], cve["public_date"], cve["exploits"]))
+            affecting_cves.append(cve["id"])
 
         retval["cves_total"] = len(cve_data)
         retval["exploited_cves_count"] = len([row[2] for row in cve_data if row[2] is True])
@@ -164,24 +168,10 @@ class GetDashboard(GetRequest):
                                     (CveRuleMapping.rule_id == InsightsRule.id) & (InsightsRule.active == True)))
                                .where(CveAccountCache.rh_account_id == rh_account))
         else:
-            rules_breakdown = (SystemVulnerabilities.select(fn.COUNT(fn.Distinct(SystemVulnerabilities.cve_id)).alias('rules_cves_count'))
-                               .join(CveRuleMapping, on=(SystemVulnerabilities.cve_id == CveRuleMapping.cve_id))
-                               .join(InsightsRule, on=((CveRuleMapping.rule_id == InsightsRule.id) & (InsightsRule.active == True)))
-                               .join(SystemPlatform, on=((SystemVulnerabilities.system_id == SystemPlatform.id) & (SystemPlatform.rh_account_id == rh_account) &
-                                                         (SystemPlatform.when_deleted.is_null(True)) &
-                                                         (SystemPlatform.stale == False) & (SystemPlatform.opt_out == False) &  # noqa: E712
-                                                         (SystemPlatform.last_evaluation.is_null(False) |
-                                                          SystemPlatform.advisor_evaluated.is_null(False)) &
-                                                         (fn.COALESCE(SystemPlatform.host_type, 'null') != HostType.EDGE)))
-                               .where(SystemVulnerabilities.rh_account_id == rh_account)
-                               .where((SystemVulnerabilities.when_mitigated.is_null(True)) |
-                                      (SystemVulnerabilities.rule_id << InsightsRule.select(InsightsRule.id)
-                                                                                    .where((InsightsRule.active == True) &
-                                                                                           (InsightsRule.rule_only == False)))))
-
-            if cyndi_request:
-                rules_breakdown = cyndi_join(rules_breakdown)
-                rules_breakdown = apply_filters(rules_breakdown, args, FILTERS, {})
+            rules_breakdown = (CveRuleMapping.select(fn.COUNT(fn.Distinct(CveRuleMapping.cve_id)).alias("rules_cves_count"))
+                                             .join(InsightsRule, on=((CveRuleMapping.rule_id == InsightsRule.id)
+                                                                     & (InsightsRule.active == True)))
+                                             .where(CveRuleMapping.cve_id << affecting_cves))
         rules_breakdown = rules_breakdown.first()
 
         retval['rules_cves_total'] = rules_breakdown.rules_cves_count


### PR DESCRIPTION
This change uses the affected CVE ids to get the number of CVEs which have some rule, we can omit the `system_vulnerabilities` scan.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
