### PR TITLE
feat(listener): provide known repo paths out of RHUI mirrorlist URLs

### DIFF
--- a/listener/upload_listener.py
+++ b/listener/upload_listener.py
@@ -114,10 +114,11 @@ async def terminate(_, loop):
     loop.stop()
 
 
-def format_vmaas_request(package_list, repo_list, basearch, modules_list=None, releasever=None):
+def format_vmaas_request(package_list, repo_list, basearch, modules_list=None, releasever=None, repo_paths=None):
     """Wrap package and repo list into the vmaas request format."""
     vmaas_request = {"package_list": package_list,
-                     "repository_list": repo_list}
+                     "repository_list": repo_list,
+                     "repository_paths": repo_paths}
     if modules_list:
         vmaas_request["modules_list"] = modules_list
     if basearch:

--- a/listener/upload_listener.py
+++ b/listener/upload_listener.py
@@ -1,9 +1,11 @@
 """Module implementing kafka listener."""
 
+import re
 import asyncio
 import hashlib
 import json
 import signal
+from urllib.parse import urlparse
 from typing import Optional, Tuple
 import flags
 
@@ -55,6 +57,11 @@ MISSING_INSIGHTS_ENTITLEMENT = Counter('ve_listener_upl_non_insights_entitlement
 LISTENER_QUEUE = mqueue.MQReader([CFG.events_topic])
 EVALUATOR_QUEUE = mqueue.MQWriter(CFG.evaluator_upload_topic)
 PAYLOAD_TRACKER_PRODUCER = mqueue.MQWriter(CFG.payload_tracker_topic)
+
+RHUI_PATH_PART = '/rhui/'
+REPO_PATH_PATTERN = re.compile("(/content/.*)")
+REPO_BASEARCH_PLACEHOLDER = "$basearch"
+REPO_RELEASEVER_PLACEHOLDER = "$releasever"
 
 WORKER_THREADS = CFG.worker_threads or 30
 
@@ -118,6 +125,37 @@ def format_vmaas_request(package_list, repo_list, basearch, modules_list=None, r
     if releasever:
         vmaas_request["releasever"] = releasever
     return json.dumps(vmaas_request)
+
+
+def format_repo_path(repo_url, basearch=None, releasever=None):
+    """Format known repository path out of base URL or mirrolist (RHUI only)"""
+    if not repo_url or not repo_url.strip():
+        return None
+
+    try:
+        parsed = urlparse(repo_url)
+    except ValueError as err:
+        LOGGER.warning("Base URL/mirrorlist parse error: %s (value: %s)", err, repo_url)
+        return None
+
+    path = parsed.path
+    path_match = REPO_PATH_PATTERN.search(path)
+    if RHUI_PATH_PART in path and path_match:
+        return _format_repo_placeholders(path_match.group(1),
+                                         basearch=basearch, releasever=releasever)
+
+    return None
+
+
+def _format_repo_placeholders(path, basearch=None, releasever=None):
+    """Format repository path by replacing placeholders"""
+    repo_path = path
+    if basearch:
+        repo_path = repo_path.replace(REPO_BASEARCH_PLACEHOLDER, basearch)
+    if releasever:
+        repo_path = repo_path.replace(REPO_RELEASEVER_PLACEHOLDER, releasever)
+
+    return repo_path
 
 
 def db_import_system(upload_data, vmaas_json: str, repo_list: list):
@@ -337,11 +375,17 @@ def parse_inventory_data(upload_data: dict) -> Tuple[Optional[str], list]:
     system_profile = upload_data["host"]["system_profile"]
     installed_packages = system_profile.get("installed_packages")
     if installed_packages:
-        repo_list = _get_repo_list(system_profile.get("yum_repos", ()))
-        modules_list = [{"module_name": m["name"], "module_stream": m["stream"]} for m in system_profile.get("dnf_modules", [])]
         basearch = system_profile.get("arch", None)
+        rhsm_version = system_profile.get("rhsm", {}).get("version", None)
+        releasever = system_profile.get("releasever", None)
+
+        repo_list, repo_paths = _get_repo_list(system_profile.get("yum_repos", ()),
+                                               basearch=basearch,
+                                               releasever=(rhsm_version or releasever))
+        modules_list = [{"module_name": m["name"], "module_stream": m["stream"]} for m in system_profile.get("dnf_modules", [])]
+
         vmaas_request = format_vmaas_request(installed_packages, repo_list, basearch, modules_list=modules_list,
-                                             releasever=system_profile.get('rhsm', {}).get('version', None))
+                                             releasever=rhsm_version, repo_paths=repo_paths)
     else:
         UPLOAD_NO_RPMDB.inc()
         LOGGER.error("Skipping inventory_id because of empty package list: %s", upload_data["host"]["id"])
@@ -349,13 +393,18 @@ def parse_inventory_data(upload_data: dict) -> Tuple[Optional[str], list]:
 
 
 def _get_repo_list(yum_repos=(), basearch=None, releasever=None):
-    """Get repo list out of yum repos"""
+    """Get repo list and repo paths out of yum repos using basearch and releasever"""
     repo_list = []
+    repo_paths = set()
     for repo in yum_repos:
         if repo.get("enabled", True) and repo.get("id", "").strip():
             repo_list.append(repo["id"].strip())
+            repo_url = repo.get("mirrorlist") or repo.get("base_url")
+            repo_path = format_repo_path(repo_url, basearch=basearch, releasever=releasever)
+            if repo_path:
+                repo_paths.add(repo_path)
 
-    return repo_list
+    return repo_list, list(repo_paths)
 
 
 def process_upload(upload_data, loop=None):

--- a/listener/upload_listener.py
+++ b/listener/upload_listener.py
@@ -376,7 +376,7 @@ def parse_inventory_data(upload_data: dict) -> Tuple[Optional[str], list]:
     system_profile = upload_data["host"]["system_profile"]
     installed_packages = system_profile.get("installed_packages")
     if installed_packages:
-        basearch = system_profile.get("arch", None)
+        basearch = system_profile.get("basearch", None) or system_profile.get("arch", None)
         rhsm_version = system_profile.get("rhsm", {}).get("version", None)
         releasever = system_profile.get("releasever", None)
 

--- a/listener/upload_listener.py
+++ b/listener/upload_listener.py
@@ -337,7 +337,7 @@ def parse_inventory_data(upload_data: dict) -> Tuple[Optional[str], list]:
     system_profile = upload_data["host"]["system_profile"]
     installed_packages = system_profile.get("installed_packages")
     if installed_packages:
-        repo_list = [r["id"].strip() for r in system_profile.get("yum_repos", []) if r.get("enabled", True) and r.get("id", "").strip()]
+        repo_list = _get_repo_list(system_profile.get("yum_repos", ()))
         modules_list = [{"module_name": m["name"], "module_stream": m["stream"]} for m in system_profile.get("dnf_modules", [])]
         basearch = system_profile.get("arch", None)
         vmaas_request = format_vmaas_request(installed_packages, repo_list, basearch, modules_list=modules_list,
@@ -346,6 +346,16 @@ def parse_inventory_data(upload_data: dict) -> Tuple[Optional[str], list]:
         UPLOAD_NO_RPMDB.inc()
         LOGGER.error("Skipping inventory_id because of empty package list: %s", upload_data["host"]["id"])
     return vmaas_request, repo_list
+
+
+def _get_repo_list(yum_repos=(), basearch=None, releasever=None):
+    """Get repo list out of yum repos"""
+    repo_list = []
+    for repo in yum_repos:
+        if repo.get("enabled", True) and repo.get("id", "").strip():
+            repo_list.append(repo["id"].strip())
+
+    return repo_list
 
 
 def process_upload(upload_data, loop=None):

--- a/tests/listener_tests/test_upload_listener.py
+++ b/tests/listener_tests/test_upload_listener.py
@@ -28,10 +28,13 @@ from common import utils
 
 PACKAGE_LIST = ['package-a', 'package-b']
 REPO_LIST = ['repo-c', 'repo-d']
+REPO_PATHS = ["/content/dist/rhel8/rhui/8/x86_64/baseos/os", "/content/dist/rhel8/rhui/8.4/x86_64/appstream/os"]
 MODULES_LIST = ['module-e', 'module-f']
 BASEARCH = "x86_64"
 RESULT_JSON = '{"package_list": ["package-a", "package-b"], ' \
               '"repository_list": ["repo-c", "repo-d"], ' \
+              '"repository_paths": ["/content/dist/rhel8/rhui/8/x86_64/baseos/os", ' \
+              '"/content/dist/rhel8/rhui/8.4/x86_64/appstream/os"], ' \
               '"modules_list": ["module-e", "module-f"], '\
               '"basearch": "x86_64"}'
 
@@ -116,7 +119,7 @@ class TestUploadListener:
 
     def test_format_vmaas_request(self):
         """test_format_vmaas_request"""
-        result = format_vmaas_request(PACKAGE_LIST, REPO_LIST, BASEARCH, modules_list=MODULES_LIST)
+        result = format_vmaas_request(PACKAGE_LIST, REPO_LIST, BASEARCH, modules_list=MODULES_LIST, repo_paths=REPO_PATHS)
         assert result
         assert result == RESULT_JSON
 

--- a/tests/listener_tests/test_upload_listener.py
+++ b/tests/listener_tests/test_upload_listener.py
@@ -4,6 +4,8 @@
 Unit tests for listener module
 """
 
+# pylint: disable=too-many-public-methods
+
 import asyncio
 from concurrent.futures import ThreadPoolExecutor
 from copy import deepcopy
@@ -13,7 +15,7 @@ import pytest
 
 import listener.upload_listener
 from listener.upload_listener import format_vmaas_request, db_import_system, process_upload, LOGGER, \
-    terminate, LISTENER_QUEUE, EVALUATOR_QUEUE, on_thread_done, \
+    terminate, LISTENER_QUEUE, EVALUATOR_QUEUE, on_thread_done, format_repo_path, \
     db_delete_system, process_delete, ImportStatus, db_import_repos, db_import_system_repos, db_init_repo_cache, \
     db_delete_other_system_repos, db_update_system, process_update, main, process_message, CFG, ListenerCtx
 from common.database_handler import DatabasePool, DatabasePoolConnection
@@ -117,6 +119,27 @@ class TestUploadListener:
         result = format_vmaas_request(PACKAGE_LIST, REPO_LIST, BASEARCH, modules_list=MODULES_LIST)
         assert result
         assert result == RESULT_JSON
+
+    def test_format_repo_path(self):
+        """Test format into repo path out of mirrorlist"""
+
+        assert format_repo_path(None) is None
+        assert format_repo_path("") is None
+        assert format_repo_path("https://rhui.redhat.com[") is None
+        assert format_repo_path("https://rhui.redhat.com/") is None
+
+        assert format_repo_path(
+            "https://rhui.redhat.com/pulp/mirror/content/dist/rhel8/rhui/8.4/x86_64/baseos/os",
+        ) == "/content/dist/rhel8/rhui/8.4/x86_64/baseos/os"
+
+        assert format_repo_path(
+            "https://rhui.redhat.com/pulp/mirror/content/dist/rhel8/rhui/$releasever/$basearch/baseos/os",
+            basearch="x86_64", releasever="8.4"
+        ) == "/content/dist/rhel8/rhui/8.4/x86_64/baseos/os"
+
+        assert format_repo_path(
+            "https://rhui.redhat.com/pulp/content/eus/rhel8/rhui/8.4/x86_64/baseos/os",
+        ) == "/content/eus/rhel8/rhui/8.4/x86_64/baseos/os"
 
     @staticmethod
     def _mark_evaluated(inventory_id: str):


### PR DESCRIPTION
Gather repository paths using a common pattern of `/content/*` and pass it to VMaaS within request as `repository_paths`.
Repository paths are taken from repository `mirrorlist` URLs. `$releasever` and `$basearch` placehoders are being substituted from newly added system profile facts (having the same name; https://github.com/RedHatInsights/inventory-schemas/pull/99).

Note that only RHUI repository paths are being sent.

VULN-2442

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
