### PR TITLE
fix: set patch_access=true with advisories feature flag

### DIFF
--- a/manager/cve_handler.py
+++ b/manager/cve_handler.py
@@ -401,7 +401,7 @@ class GetCveSystems(GetRequest):
     @classmethod
     @RBAC.need_permissions(RbacRoutePermissions.VULNERABILITY_RESULTS)
     @RBAC.need_permissions_filter_value(RbacFilterRoutePermissions.REPORTABLE_ENDPOINTS)
-    def handle_get(cls, **kwargs):
+    def handle_get(cls, **kwargs):  # pylint: disable=too-many-branches
         """Gets systems affected by a CVE"""
         synopsis = kwargs["cve_id"]
         cls._cve_exists(synopsis)
@@ -481,8 +481,15 @@ class GetCveSystems(GetRequest):
                     record = cls._build_attributes(sys)
                     result.append({"type": "system", "id": sys["inventory_id"], "attributes": record})
 
+        # TODO: remove with CFG.disable_patch_requests
+        # set patch_access based on presence of `advisories_list`
+        # override by actual patch_access.status if present
+        meta_patch_access = CFG.disable_patch_requests or None
+        if patch_access:
+            meta_patch_access = patch_access.status
+
         response["meta"] = asys_view.get_metadata()
-        response["meta"]["patch_access"] = patch_access.status if patch_access else None
+        response["meta"]["patch_access"] = meta_patch_access
         response["links"] = asys_view.get_pagination_links()
         response["data"] = cls._format_data(list_arguments["data_format"], result, ids_only=cls._ids_only)
         return response

--- a/manager/system_handler.py
+++ b/manager/system_handler.py
@@ -502,8 +502,15 @@ class GetSystemsCves(GetRequest):
         else:
             result = cves
 
+        # TODO: remove with CFG.disable_patch_requests
+        # set patch_access based on presence of `advisories_list`
+        # override by actual patch_access.status if present
+        meta_patch_access = CFG.disable_patch_requests or None
+        if patch_access:
+            meta_patch_access = patch_access.status
+
         response["meta"] = cves_view.get_metadata()
-        response["meta"]["patch_access"] = patch_access.status if patch_access else None
+        response["meta"]["patch_access"] = meta_patch_access
         response["links"] = cves_view.get_pagination_links()
         response["data"] = cls._format_data(list_arguments["data_format"], result, ids_only=cls._ids_only)
         return response


### PR DESCRIPTION
VULN-2515

UI hides Advisories columne when patch_access is False or None, we need to set it to True when using CFG.disable_patch_request feature
## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
