### PR TITLE
chore: drop distutils.strtobool

### DIFF
--- a/common/config.py
+++ b/common/config.py
@@ -2,12 +2,13 @@
 Use Clowder config or env vars config.
 """
 import os
-from distutils.util import strtobool  # pylint: disable=import-error, no-name-in-module
 import tempfile
 
 import app_common_python
 from app_common_python.types import BrokerConfigAuthtypeEnum
 from aiokafka.helpers import create_ssl_context
+
+from common.strtobool import strtobool
 
 
 class Singleton(type):
@@ -85,7 +86,7 @@ class BaseConfig:
         self.default_route = f"{os.getenv('PATH_PREFIX', '/api')}/{os.getenv('APP_NAME', 'vulnerability')}/{os.getenv('API_VERSION', 'v1')}"
         self.read_only_mode = strtobool(os.environ.get("READ_ONLY_MODE", "FALSE"))
 
-        self.disable_patch_requests = bool(strtobool(os.getenv("DISABLE_PATCH_REQUESTS", "FALSE")))
+        self.disable_patch_requests = strtobool(os.getenv("DISABLE_PATCH_REQUESTS", "FALSE"))
         self.patch_id_query_filter = os.getenv("PATCH_ID_QUERY_FILTER", "?filter[id]")
         self.patch_filter_prefix = "=in:"
         self.patch_advisories_api = os.getenv("PATCH_ADVISORIES_API", "/api/patch/v1/advisories")

--- a/common/strtobool.py
+++ b/common/strtobool.py
@@ -1,0 +1,21 @@
+"""Module providing `strtobool` function as replacement of distutils.strtobool."""
+
+
+def strtobool(val: str) -> bool:
+    """Convert a string representation of truth to bool.
+
+    True values are y, yes, t, true, on and 1; false values are n, no, f, false, off and 0.
+    Raises TypeError if `val` is not string.
+    Raises ValueError if `val` is anything else.
+    """
+    if not isinstance(val, str):
+        raise TypeError(f"`{val}` is not of type str")
+    trues = ("y", "yes", "t", "true", "on", "1")
+    falses = ("n", "no", "f", "false", "off", "0")
+
+    val = val.lower()
+    if val in trues:
+        return True
+    if val in falses:
+        return False
+    raise ValueError(f"`{val}` not in {trues + falses}")

--- a/manager/base.py
+++ b/manager/base.py
@@ -7,7 +7,6 @@ from enum import Enum
 from io import StringIO
 import json
 from math import floor
-from distutils.util import strtobool  # pylint: disable=import-error, no-name-in-module
 import traceback
 from urllib.parse import unquote
 from time import sleep
@@ -24,6 +23,7 @@ from common.logging import get_logger
 from common.peewee_model import (CveMetadata, CveRuleMapping, InsightsRule, RHAccount, SystemPlatform, SystemVulnerabilities, InventoryHosts,
                                  DB, DB_READ_REPLICA)
 from common.peewee_conditions import (system_is_active)
+from common.strtobool import strtobool
 from common.utils import send_slack_notification, format_datetime, validate_cve_cache_keepalive
 from .filters import apply_filters
 from .rbac_manager import RbacManager


### PR DESCRIPTION
`distutils.strtobool` returns `int` and is deprecated since python3.10
## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
