### PR TITLE
fix(evaluator): update remediation type and advisory

### DIFF
--- a/evaluator/evaluator.py
+++ b/evaluator/evaluator.py
@@ -47,7 +47,7 @@ EVALUATOR_RESULTS = mqueue.MQWriter(CFG.evaluator_results_topic)
 MAIN_LOOP = asyncio.get_event_loop()
 MAX_MESSAGES_SEMAPHORE = asyncio.BoundedSemaphore(CFG.max_loaded_evaluator_msgs)
 
-Cve = namedtuple("Cve", ["name", "errata"])
+Cve = namedtuple("Cve", ["name", "errata", "remediation_type_id"])
 ErrataHasPlaybook = namedtuple("ErrataHasPlaybook", ["errata", "has_playbook"])
 CveIdErrata = namedtuple("CveIdErrata", ["id", "errata"])
 
@@ -55,7 +55,7 @@ CveIdErrata = namedtuple("CveIdErrata", ["id", "errata"])
 async def _load_cves_for_inventory_id(rh_account_id, system_id, conn):
     system_cves_map = {}
     for record in await conn.fetch("""select cm.id, cm.cve, sv.id as sv_id, sv.when_mitigated, sv.mitigation_reason, sv.advisories,
-                                             ir.active, ir.playbook_count, ir.rule_only
+                                             ir.active, ir.playbook_count, ir.rule_only, sv.remediation_type_id
                                         from system_vulnerabilities sv
                                         join cve_metadata cm on sv.cve_id = cm.id
                                         left outer join insights_rule ir on sv.rule_id = ir.id
@@ -67,7 +67,8 @@ async def _load_cves_for_inventory_id(rh_account_id, system_id, conn):
                                           "advisories": record["advisories"],
                                           "active_rule": record["active"],
                                           "playbook_count": record["playbook_count"],
-                                          "rule_only": record["rule_only"]}
+                                          "rule_only": record["rule_only"],
+                                          "remediation_type_id": record["remediation_type_id"]}
     return system_cves_map
 
 
@@ -134,18 +135,20 @@ async def _store_new_cves(rh_account_id, system_id, new_cves, conn):
     return new_sys_vulns
 
 
-async def _update_cves_advisories(rh_account_id, system_id, cves_need_udpate, conn, system_cves_map):
+async def _update_cves(rh_account_id, system_id, cves_need_udpate, conn, system_cves_map):
+    """Update CVE advisories and remediation_type_id."""
     if not cves_need_udpate:
         return
 
     cve_system_list = []
     for cve in cves_need_udpate:
-        cve_system_list.append((system_id, system_cves_map[cve.name]["cve_id"], cve.errata))
+        cve_system_list.append((system_id, system_cves_map[cve.name]["cve_id"], cve.errata, cve.remediation_type_id))
 
     await conn.executemany(f"""update system_vulnerabilities as sv
-                               set advisories = v.advisories
-                               from (values ($1::int, $2::int, $3::text))
-                                 as v(system_id, cve_id, advisories)
+                               set advisories = v.advisories,
+                                   remediation_type_id = v.remediation_type_id
+                               from (values ($1::int, $2::int, $3::text, $4::int))
+                                 as v(system_id, cve_id, advisories, remediation_type_id)
                                where sv.rh_account_id = {rh_account_id}
                                  and sv.system_id = v.system_id
                                  and sv.cve_id = v.cve_id""", cve_system_list)
@@ -217,10 +220,14 @@ async def _vmaas_request_cves(vmaas_request_json):
                                                         vmaas_request_json)
     if vulnerabilities_response_json is not None:
         for cve in vulnerabilities_response_json['cve_list']:
-            playbook_cves.append(Cve(cve["cve"], ",".join(sorted(cve["errata"] or [])) or None))
+            playbook_cves.append(Cve(
+                cve["cve"],
+                ",".join(sorted(cve["errata"] or [])) or None,
+                2,  # remediation_type_id=2 (Playbook)
+            ))
         for cve in vulnerabilities_response_json['manually_fixable_cve_list']:
             # manually fixable CVE never has any errata
-            manually_fixable_cves.append(Cve(cve["cve"], None))
+            manually_fixable_cves.append(Cve(cve["cve"], None, 1))
     else:
         return None, None
     return playbook_cves, manually_fixable_cves
@@ -262,7 +269,7 @@ async def evaluate_vmaas(system_platform, acc_num, org_id, conn):
                 # it was mitigated, now its not
                 unmitigated_cves[cve.name] = ErrataHasPlaybook(cve.errata, True)
                 unmit_sys_vulns.append((system_cves_map[cve.name]["sv_id"], system_cves_map[cve.name]["cve_id"]))
-            elif cve.errata != system_cves_map[cve.name]["advisories"]:
+            elif cve.errata != system_cves_map[cve.name]["advisories"] or system_cves_map[cve.name]["remediation_type_id"] != 2:
                 cves_needed_update.append(cve)
         else:
             # update errata in unprocessed list
@@ -279,6 +286,8 @@ async def evaluate_vmaas(system_platform, acc_num, org_id, conn):
                     # it was mitigated, now its not
                     unmitigated_cves[cve.name] = ErrataHasPlaybook(cve.errata, False)
                     unmit_sys_vulns.append((system_cves_map[cve.name]["sv_id"], system_cves_map[cve.name]["cve_id"]))
+                elif cve.errata != system_cves_map[cve.name]["advisories"] or system_cves_map[cve.name]["remediation_type_id"] != 1:
+                    cves_needed_update.append(cve)
             else:
                 # update errata in unprocessed list
                 if cve.name in unprocessed_cves:
@@ -295,7 +304,7 @@ async def evaluate_vmaas(system_platform, acc_num, org_id, conn):
             system_cves.append(cve)
 
     new_sys_vulns = await _store_new_cves(rh_account_id, system_id, new_cves, conn)
-    await _update_cves_advisories(rh_account_id, system_id, cves_needed_update, conn, system_cves_map)
+    await _update_cves(rh_account_id, system_id, cves_needed_update, conn, system_cves_map)
     await _update_mitigated_cves(rh_account_id, system_id, mitigated_cves, conn, system_cves_map)
     await _update_unmitigated_cves(rh_account_id, system_id, unmitigated_cves, conn, system_cves_map)
     await _update_system(system_id, len(system_cves), conn)


### PR DESCRIPTION
when CVE became reported in `cves` from vmaas - set advisories and remediation_type_id=2 when reported in `manually_fixable_cves` - set advisories=None, remediation_type_id=1

VULN-2515

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
