### PR TITLE
fix: require package epoch

### DIFF
--- a/evaluator/evaluator.py
+++ b/evaluator/evaluator.py
@@ -215,7 +215,7 @@ async def _vmaas_request_cves(vmaas_request_json):
         # no need to evaluate system without packages or repositories by vmaas
         return playbook_cves, manually_fixable_cves
 
-    vmaas_request_json["extended"] = True  # TODO: delete later when all vmaas_jsons have 'extended' field
+    vmaas_request_json["epoch_required"] = True
     vulnerabilities_response_json = await vmaas_request(CFG.vmaas_vulnerabilities_endpoint,
                                                         vmaas_request_json)
     if vulnerabilities_response_json is not None:

--- a/evaluator/logic.py
+++ b/evaluator/logic.py
@@ -153,6 +153,7 @@ class EvaluatorLogic:
         if not vmaas_json.get("package_list", []) or not vmaas_json.get("repository_list", []):
             return playbook_cves, manually_fixable_cves
 
+        vmaas_json["epoch_required"] = True
         vmaas_response = await vmaas_request(CFG.vmaas_vulnerabilities_endpoint, vmaas_json)
         if vmaas_response:
             for cve in vmaas_response["cve_list"]:


### PR DESCRIPTION
we should not evaluate packages without epoch, it happens when inventory sends an incorrect package_list and we then show incorrect CVEs because vmaas assumes that epoch=0 if it is not provided

now, vmaas returns 400 if epoch is not present for a package and epoch_required=true, evaluation of a system is then skipped by evaluator

RHINENG-390

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
