### PR TITLE
fix(evaluator): force extended output during recalc of old systems

### DIFF
--- a/evaluator/logic.py
+++ b/evaluator/logic.py
@@ -251,6 +251,7 @@ class EvaluatorLogic:
             return playbook_cves, manually_fixable_cves, unpatched_cves
 
         vmaas_json["epoch_required"] = True
+        vmaas_json["extended"] = True
         vmaas_response = await vmaas_request(CFG.vmaas_vulnerabilities_endpoint, vmaas_json)
         if vmaas_response:
             for cve in vmaas_response["cve_list"]:


### PR DESCRIPTION
extended could be now removed from system profile JSON as well

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
