### PR TITLE
fix(listener): use releasever in vmaas_req

### DIFF
--- a/listener/inventory_processor.py
+++ b/listener/inventory_processor.py
@@ -130,14 +130,12 @@ class InventoryMsgProcessor(BaseProcessor):
         if installed_packages:
             basearch = system_profile.get("basearch") or system_profile.get("arch")
             rhsm_ver = system_profile.get("rhsm", {}).get("version")
-            releasever = system_profile.get("releasever")
+            releasever = rhsm_ver or system_profile.get("releasever")
 
-            repo_list, repo_paths = self._format_repo_list(
-                system_profile.get("yum_repos", ()), basearch=basearch, releasever=(rhsm_ver or releasever)
-            )
+            repo_list, repo_paths = self._format_repo_list(system_profile.get("yum_repos", ()), basearch=basearch, releasever=releasever)
             modules_list = [{"module_name": m["name"], "module_stream": m["stream"]} for m in system_profile.get("dnf_modules", [])]
             vmaas_request = self._format_vmaas_req(
-                installed_packages, repo_list, basearch, modules_list=modules_list, releasever=rhsm_ver, repo_paths=repo_paths
+                installed_packages, repo_list, basearch, modules_list=modules_list, releasever=releasever, repo_paths=repo_paths
             )
         return vmaas_request, repo_list
 


### PR DESCRIPTION
Utilize relelasever from a system profile if RHSM version isn't set. This should improve reporting from RHUI systems.

VULN-2716

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
