### PR TITLE
Mark each static assets dir as a git "safe.directory"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,12 @@ RUN if [ "${STATIC_ASSETS}" == 1 ] ; then \
         update-ca-trust extract && \
         git clone https://gitlab.cee.redhat.com/vmaas/vmaas-assets.git /engine/vmaas_assets_git && \
         git clone https://gitlab.cee.redhat.com/insights-rules/insights-playbooks.git /engine/insights_playbooks_git && \
-        git clone "https://$GIT_TOKEN@github.com/RedHatInsights/insights-content-vulnerability.git" /engine/insights_content_vulnerability_git ; \
+        git clone "https://$GIT_TOKEN@github.com/RedHatInsights/insights-content-vulnerability.git" /engine/insights_content_vulnerability_git && \
+        # below is needed to avoid git 'detected dubious ownership' error when running as a rootless container...
+        git config --system --add safe.directory /engine/vmaas_assets_git && \
+        git config --system --add safe.directory /engine/insights_playbooks_git && \
+        git config --system --add safe.directory /engine/insights_content_vulnerability_git && \
+        echo "Cloned static assets" ; \
     fi
 
 USER insights


### PR DESCRIPTION
When running rootless in OpenShift, the container runs rootless and therefore starts up with a random uid. The user ownership change on the assets directories now causes this git error:

```
sh-4.4$ git rev-parse HEAD
fatal: detected dubious ownership in repository at '/engine/insights_content_vulnerability_git'
To add an exception for this directory, call:

	git config --global --add safe.directory /engine/insights_content_vulnerability_git
```

This PR marks the directories as "git safe" at the system level using `git config --system` instead of `git config --global` (using `--global` when executed as `root` stores the git config in `/root/.gitconfig` and this config will not be read by the non-root container user)
