### PR TITLE
SC: Mark each assets directory as git 'safe.directory'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,12 @@ RUN if [ "${STATIC_ASSETS}" == 1 ] ; then \
         update-ca-trust extract && \
         git clone https://gitlab.cee.redhat.com/vmaas/vmaas-assets.git /engine/vmaas_assets_git && \
         git clone https://gitlab.cee.redhat.com/insights-rules/insights-playbooks.git /engine/insights_playbooks_git && \
-        git clone "https://$GIT_TOKEN@github.com/RedHatInsights/insights-content-vulnerability.git" /engine/insights_content_vulnerability_git ; \
+        git clone "https://$GIT_TOKEN@github.com/RedHatInsights/insights-content-vulnerability.git" /engine/insights_content_vulnerability_git && \
+        # below is needed to avoid git 'detected dubious ownership' error when running as a rootless container...
+        git config --system --add safe.directory /engine/vmaas_assets_git && \
+        git config --system --add safe.directory /engine/insights_playbooks_git && \
+        git config --system --add safe.directory /engine/insights_content_vulnerability_git && \
+        echo "Cloned static assets" ; \
     fi
 
 USER insights


### PR DESCRIPTION
Cherry-picking the Dockerfile change from https://github.com/RedHatInsights/vulnerability-engine/pull/1458 into the security-compliance branch