### PR TITLE
fix(evaluator): correctly use the rule results

### DIFF
--- a/evaluator/logic.py
+++ b/evaluator/logic.py
@@ -47,6 +47,7 @@ class EvaluatorLogic:
         self.package_name_cache: Dict[str, PackageNameCache] = {}
         self.cpe_cache: Dict[str, CpeCache] = {}
         self.vulnerable_package_cache: Dict[(int, int), VulnerablePackageCache] = {}
+        self.skipped_rules = ["CVE_2017_5715_cpu_virt|VIRT_CVE_2017_5715_CPU_3_ONLYKERNEL", "CVE_2017_5715_cpu_virt"]
 
     async def init(self):
         """Async constructor"""
@@ -530,15 +531,27 @@ class EvaluatorLogic:
         for cve, hit_details in rule_results["rule_hits"].items():
             cve_id = await self._get_or_upsert_cve(cve)
 
+            # TODO: remove this once CVE_2017_5753_4_cpu_kernel and CVE_2017_5715_cpu_virt are merged
             rule = hit_details["rule_id"]
+            if rule in self.skipped_rules:
+                continue
+
             rule_cache = await self._get_or_upsert_rule(rule, hit_details["details"], rule_cache, conn)
             rule_db = rule_cache[rule]
 
             # if the system is not vulnerable to CVE from vmaas, we expect that it does not have advisory
             vulnerability = sys_vuln_rows.get(cve)
-            if vulnerability:
+            mitigation_reason = hit_details.get("cves", {}).get(cve)
+            if vulnerability and not mitigation_reason:
                 # system was vulnerable for cve from vmaas and also is for rule
                 vulnerability.state = VulnerabilityState.VULNERABLE_BY_RULE_AND_PACKAGE
+            elif vulnerability and mitigation_reason:
+                # system was vulnerable for cve from vmaas but not from by rules -> abnv
+                vulnerability.add_rule_info(rule_db.id, hit_details["details"], rule_db.playbook_count, mitigation_reason)
+                vulnerability.state = VulnerabilityState.VULNERABLE_BY_PACKAGE_NOT_RULE
+            elif mitigation_reason:
+                # system is not vulnerable from vmaas nor rules
+                continue
             else:
                 # system is vulnerable for cve from rule, but not from vmaas
                 vulnerability = SystemVulnerabilitiesRow(
@@ -563,8 +576,12 @@ class EvaluatorLogic:
             if not package_vulnerability:
                 continue
 
-            # system was marked vulnerable from vmaas but not from by rules -> abnv
+            # TODO: remove this once CVE_2017_5753_4_cpu_kernel and CVE_2017_5715_cpu_virt are merged
             rule = pass_details["rule_id"]
+            if rule in self.skipped_rules:
+                continue
+
+            # system was marked vulnerable from vmaas but not from by rules -> abnv
             rule_cache = await self._get_or_upsert_rule(rule, pass_details["details"], rule_cache, conn, rule_only=True)
             rule_db = rule_cache[rule]
 


### PR DESCRIPTION
VULN-2775

The rule arrive at little inconvenient format, which I missed when rewriting this evaluation part.
```
"rule_hits":{
      "CVE-2017-5753":{
         "details":"{\"cves\": {\"CVE-2017-5753\": \"The current combination and configuration of the CPU and kernel is not vulnerable.\", \"CVE-2017-5715\": false, \"CVE-2017-5754\": \"The current combination and configuration of the CPU and kernel is not vulnerable.\"}, \"type\": \"rule\", \"error_key\": \"KERNEL_CVE_2017_5753_4_CPU_ERROR_3\"}",
         "rule_id":"CVE_2017_5753_4_cpu_kernel|KERNEL_CVE_2017_5753_4_CPU_ERROR_3"
}}
```
Even if this is in the `rule_hits` object, the system is not vulnerable to this CVE, because inside the `["rule_hits"]["CVE-2017-5753"][˝details"]["cves"]["CVE-2017-5753"]` the value is string, which is mitigation reason. If the value is false, then the system is vulnerable to this CVE, thus the evaluation is wrong right now.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
