### PR TITLE
feat: count edge systems affected in

### DIFF
--- a/common/feature_flags.py
+++ b/common/feature_flags.py
@@ -14,6 +14,9 @@ CFG = Config()
 APP_NAME = "vulnerability-engine"
 LOGGER = get_logger(__name__)
 
+# Flag toggles
+EDGE_PARITY_FEATURE = "vulnerability.edge_parity"
+
 
 class UnleashClientProxy:
     def __init__(self):

--- a/database/schema/ve_db_dev_data.sql
+++ b/database/schema/ve_db_dev_data.sql
@@ -107,7 +107,8 @@ INSERT INTO insights_rule (id, name, active, rule_only) VALUES
 (9, 'CVE_2018_12207_cpu_kernel', 'T', 'T'),
 (10, 'CVE_2018_3620_cpu_kernel', 'F', 'T'),
 (11, 'CVE_2019_1125_kernel', 'T', 'T'),
-(12, 'CVE_2018_12130_cpu_kernel', 'T', 'T');
+(12, 'CVE_2018_12130_cpu_kernel', 'T', 'T'),
+(13, 'CVE_2022_1_edge_kernel', 'T', 'T');
 
 INSERT INTO cve_rule_mapping (cve_id, rule_id) VALUES
 (1, 1),
@@ -129,7 +130,8 @@ INSERT INTO cve_rule_mapping (cve_id, rule_id) VALUES
 (8, 11),
 (9, 11),
 (10, 12),
-(11, 12);
+(11, 12),
+(17, 13);
 
 INSERT INTO system_vulnerabilities (id, rh_account_id, system_id, cve_id, first_reported, when_mitigated, status_id, rule_id, rule_hit_details) VALUES
 (0, 0, 3, 1, '2018-03-01 12:00:00-04', NULL, 3, NULL, NULL),
@@ -187,7 +189,7 @@ INSERT INTO system_vulnerabilities (id, rh_account_id, system_id, cve_id, first_
 (52, 0, 18, 3, '2018-04-01 12:00:00-04', NULL, 2, NULL, NULL),
 (53, 0, 18, 8, '2018-04-01 12:00:00-04', NULL, 2, 4, '{"rule_hit": "detail"}'),
 (54, 0, 20, 17, '2021-09-01 12:00:00-04', NULL, 2, NULL, NULL),
-(55, 0, 21, 17, '2021-03-01 12:00:00-04', NULL, 2, NULL, NULL),
+(55, 0, 21, 17, '2021-03-01 12:00:00-04', NULL, 2, 12, '{"rule_hit": "detail"}'),
 (56, 0, 5, 19, '2021-03-01 12:00:00-04', NULL, 2, NULL, NULL);
 
 INSERT INTO system_vulnerabilities (id, rh_account_id, system_id, cve_id, first_reported, when_mitigated, status_id, rule_id, rule_hit_details, mitigation_reason) VALUES

--- a/develfeatureflags.json
+++ b/develfeatureflags.json
@@ -14,6 +14,20 @@
       ],
       "strategy": "default",
       "parameters": {}
+    },
+    {
+      "name": "vulnerability.edge_parity",
+      "type": "release",
+      "enabled": false,
+      "stale": false,
+      "strategies": [
+        {
+          "name": "default",
+          "parameters": {}
+        }
+      ],
+      "strategy": "default",
+      "parameters": {}
     }
   ]
 }

--- a/manager/base.py
+++ b/manager/base.py
@@ -28,6 +28,8 @@ from prometheus_client import Histogram
 from .filters import apply_filters
 from .rbac_manager import RbacManager
 from common.config import Config
+from common.feature_flags import EDGE_PARITY_FEATURE
+from common.feature_flags import UNLEASH
 from common.identity import get_identity
 from common.logging import get_logger
 from common.peewee_conditions import (system_is_active)
@@ -635,6 +637,15 @@ def update_cve_cache_keepalive(account_id, last_timestamp):
     """Update keepalive timestamp for CVE cache in account. Used for maintaining cache only for active accounts."""
     if not validate_cve_cache_keepalive(last_timestamp, 1):
         RHAccount.update(cve_cache_keepalive=datetime.now(timezone.utc)).where(RHAccount.id == account_id).execute()
+
+
+def edge_feature_arg():
+    """Return value for system_is_active edge argument based on a feature flag value.
+
+    flag_enabled == False -> edge = False -- selects traditional systems only
+    flag_enabled == True  -> edge = None -- selects all systems, edge systems included
+    """
+    return None if UNLEASH.is_enabled(EDGE_PARITY_FEATURE) else False
 
 
 def unique_bool_list(bool_list):

--- a/manager/base.py
+++ b/manager/base.py
@@ -548,7 +548,7 @@ def get_mapping(cves: List[int], subquery, rh_account_id):
                           .dicts())
 
 
-def get_subquery(cves: List[int], rh_account_id):
+def get_subquery(cves: List[int], rh_account_id, edge=False):
     """Return subquery, None if `rh_account_id` is None"""
     # pylint: disable=singleton-comparison
     if rh_account_id is None:
@@ -556,14 +556,14 @@ def get_subquery(cves: List[int], rh_account_id):
 
     subquery = (SystemVulnerabilities.select(SystemVulnerabilities.id, SystemVulnerabilities.rule_id, SystemVulnerabilities.cve_id)
                                      .join(SystemPlatform, on=((SystemVulnerabilities.system_id == SystemPlatform.id) &
-                                                               system_is_active(rh_account_id=rh_account_id)))
+                                                               system_is_active(rh_account_id=rh_account_id, edge=edge)))
                                      .where(SystemVulnerabilities.cve_id.in_(cves))
                                      .where(SystemVulnerabilities.mitigation_reason.is_null(True))
                                      .where((SystemVulnerabilities.rh_account_id == rh_account_id)))
     return cyndi_join(subquery)
 
 
-def get_rules_for_cves(cves: list, rh_account=None) -> dict:
+def get_rules_for_cves(cves: list, rh_account=None, edge=False) -> dict:
     """Return associated rules for a CVE"""
     # pylint: disable=singleton-comparison, unsubscriptable-object
     rules_map = {}
@@ -576,7 +576,7 @@ def get_rules_for_cves(cves: list, rh_account=None) -> dict:
         except IndexError:
             pass
 
-    subquery = get_subquery(cves, rh_account_id)
+    subquery = get_subquery(cves, rh_account_id, edge)
     mapping = get_mapping(cves, subquery, rh_account_id)
 
     for row in mapping:

--- a/manager/base.py
+++ b/manager/base.py
@@ -602,13 +602,13 @@ def get_rules_for_cves(cves: list, rh_account=None, edge=False) -> dict:
     return rules_map
 
 
-def get_system_count(rh_account, include_cyndi=True, filters=None, filters_args=None):
+def get_system_count(rh_account, include_cyndi=True, filters=None, filters_args=None, edge=False):
     """Get count of nonstale, nonoptouted, evaluated user systems"""
     # pylint: disable=singleton-comparison
     query = SystemPlatform.select(fn.COUNT(SystemPlatform.id).alias("count"))\
         .where((SystemPlatform.rh_account_id == rh_account)
                & ((SystemPlatform.last_evaluation.is_null(False)) | (SystemPlatform.advisor_evaluated.is_null(False)))
-               & system_is_active(rh_account_id=rh_account))
+               & system_is_active(rh_account_id=rh_account, edge=edge))
 
     if include_cyndi:
         query = cyndi_join(query)

--- a/manager/cve_handler.py
+++ b/manager/cve_handler.py
@@ -20,6 +20,7 @@ from .base import ApplicationException
 from .base import cyndi_join
 from .base import DEFAULT_BUSINESS_RISK
 from .base import DEFAULT_STATUS
+from .base import edge_feature_arg
 from .base import get_account_data
 from .base import get_or_create_account
 from .base import get_rules_for_cves
@@ -396,7 +397,7 @@ class GetCves(GetRequest):
                                        CveMetadata.exploit_data)
                     .join(CveImpact, on=(CveMetadata.impact_id == CveImpact.id))
                     .where(CveMetadata.cve == synopsis)).dicts()[0]
-            rules_map = get_rules_for_cves([data["id"]], connexion.context["user"])
+            rules_map = get_rules_for_cves([data["id"]], connexion.context["user"], edge=edge_feature_arg())
             retval = {
                 "celebrity_name": str_or_none(data["celebrity_name"]),
                 "cvss2_metrics": str_or_none(data["cvss2_metrics"]),

--- a/manager/cve_handler.py
+++ b/manager/cve_handler.py
@@ -449,6 +449,9 @@ class GetCves(GetRequest):
             retval["status_id"] = 0
             retval["status_text"] = None
 
+        # argument for controling host types in system counts
+        edge = edge_feature_arg()
+
         # affected but not vulnerable systems count
         # pylint: disable=singleton-comparison
         not_vulnerable = (SystemVulnerabilities
@@ -458,7 +461,7 @@ class GetCves(GetRequest):
                           .join(InsightsRule, on=(SystemVulnerabilities.rule_id == InsightsRule.id))
                           .where((SystemVulnerabilities.rh_account_id == rh_account_id))
                           .where(CveMetadata.cve == synopsis)
-                          .where(system_is_active(rh_account_id=rh_account_id))
+                          .where(system_is_active(rh_account_id=rh_account_id, edge=edge))
                           .where(system_is_abnv()))
         not_vulnerable = cyndi_join(not_vulnerable)
         retval["affected_but_not_vulnerable"] = not_vulnerable.scalar()
@@ -474,7 +477,7 @@ class GetCves(GetRequest):
                                .join(InsightsRule, JOIN.LEFT_OUTER, on=(InsightsRule.id == SystemVulnerabilities.rule_id))
                                .where(CveMetadata.cve == synopsis)
                                .where(SystemVulnerabilities.rh_account_id == rh_account_id)
-                               .where(system_is_active(rh_account_id=rh_account_id))
+                               .where(system_is_active(rh_account_id=rh_account_id, edge=edge))
                                .where(system_is_vulnerable())
                                .group_by(SystemVulnerabilities.status_id)
                                .dicts())
@@ -487,7 +490,7 @@ class GetCves(GetRequest):
                                  .join(CveMetadata, on=(VulnerablePackageCVE.cve_id == CveMetadata.id))
                                  .where(CveMetadata.cve == synopsis)
                                  .where(SystemVulnerablePackage.rh_account_id == rh_account_id)
-                                 .where(system_is_active(rh_account_id=rh_account_id))
+                                 .where(system_is_active(rh_account_id=rh_account_id, edge=edge))
                                  .dicts())
         status_detail_unfixed = cyndi_join(status_detail_unfixed)
 

--- a/manager/dashbar_handler.py
+++ b/manager/dashbar_handler.py
@@ -9,6 +9,7 @@ from peewee import SQL
 
 from .base import cyndi_join
 from .base import DISABLE_ACCOUNT_CACHE
+from .base import edge_feature_arg
 from .base import get_account_data
 from .base import GetRequest
 from .base import is_not_cacheable_request
@@ -82,7 +83,7 @@ class GetDashbar(GetRequest):
                      .join(CveRuleMapping, JOIN.LEFT_OUTER, on=((SystemVulnerabilities.cve_id == CveRuleMapping.cve_id)))
                      .join(InsightsRule, JOIN.LEFT_OUTER, on=(CveRuleMapping.rule_id == InsightsRule.id))
                      .join(SystemPlatform, on=((SystemVulnerabilities.system_id == SystemPlatform.id) &
-                                               system_is_active(rh_account_id=rh_account)))
+                                               system_is_active(rh_account_id=rh_account, edge=edge_feature_arg())))
                      .where(SystemVulnerabilities.rh_account_id == rh_account)
                      .where(system_is_vulnerable())
                      .where(CveMetadata.advisories_list != SQL("'[]'")))

--- a/manager/dashboard_handler.py
+++ b/manager/dashboard_handler.py
@@ -11,6 +11,7 @@ from peewee import SQL
 
 from .base import cyndi_join
 from .base import DISABLE_ACCOUNT_CACHE
+from .base import edge_feature_arg
 from .base import get_account_data
 from .base import get_system_count
 from .base import GetRequest
@@ -98,7 +99,11 @@ class GetDashboard(GetRequest):
         args = cls._parse_arguments(kwargs, args_desc)
         cyndi_request = is_not_cacheable_request(args)
         rh_account, cve_cache_from, cve_cache_keepalive, _ = get_account_data(connexion.context["user"])
-        retval["system_count"] = get_system_count(rh_account, True, FILTERS, args)
+
+        # argument for controling host types in system counts
+        edge = edge_feature_arg()
+
+        retval["system_count"] = get_system_count(rh_account, True, FILTERS, args, edge=edge)
 
         # API using cache, set keepalive for account to enable maintaining cache
         update_cve_cache_keepalive(rh_account, cve_cache_keepalive)
@@ -112,7 +117,7 @@ class GetDashboard(GetRequest):
             active_cves_subquery = (SystemVulnerabilities
                                     .select(fn.Distinct(SystemVulnerabilities.cve_id).alias("cve_id_"))
                                     .join(SystemPlatform, on=((SystemVulnerabilities.system_id == SystemPlatform.id) &
-                                                              system_is_active(rh_account_id=rh_account)))
+                                                              system_is_active(rh_account_id=rh_account, edge=edge)))
                                     .where(SystemVulnerabilities.rh_account_id == rh_account)
                                     .where(system_is_vulnerable()))
             if cyndi_request:
@@ -200,7 +205,7 @@ class GetDashboard(GetRequest):
                             .select(SystemVulnerabilities.rule_id.alias("rule_id_"),
                                     fn.Count(fn.Distinct(SystemVulnerabilities.system_id)).alias("systems_affected_"))
                             .join(SystemPlatform, on=((SystemVulnerabilities.system_id == SystemPlatform.id) &
-                                                      system_is_active(rh_account_id=rh_account)))
+                                                      system_is_active(rh_account_id=rh_account, edge=edge)))
                             .where(SystemVulnerabilities.rh_account_id == rh_account)
                             .where(system_has_rule_hit())
                             .group_by(SystemVulnerabilities.rule_id))

--- a/manager/main.py
+++ b/manager/main.py
@@ -20,6 +20,7 @@ from .base import wait_on_cyndi as _wait_on_cyndi
 from .rbac_manager import RbacException
 from common.config import Config
 from common.constants import APP_VERSION
+from common.feature_flags import initialize_unleash
 from common.logging import get_logger
 from common.logging import init_logging
 from common.peewee_database import DB
@@ -97,6 +98,7 @@ def create_app(spec_files, wait_on_cyndi=True):
 
 
 init_logging(num_servers=int(CFG.gunicorn_workers))
+initialize_unleash()
 #  gunicorn expects an object called 'application' hence the pylint disable
 application = create_app({CFG.default_route: 'manager.spec.yaml',  # pylint: disable=invalid-name
                           "": 'manager.healthz.spec.yaml'})

--- a/manager/report_handler.py
+++ b/manager/report_handler.py
@@ -12,6 +12,7 @@ from peewee import SQL
 
 from .base import cyndi_join
 from .base import DISABLE_ACCOUNT_CACHE
+from .base import edge_feature_arg
 from .base import get_account_data
 from .base import get_system_count
 from .base import GetRequest
@@ -100,7 +101,11 @@ class GetExecutive(GetRequest):
         rh_account, cve_cache_from, cve_cache_keepalive, _ = get_account_data(connexion.context["user"])
         if rh_account is None:
             return retval
-        retval["system_count"] = get_system_count(rh_account)
+
+        # argument for controling host types in system counts
+        edge = edge_feature_arg()
+
+        retval["system_count"] = get_system_count(rh_account, edge=edge)
         if retval["system_count"] == 0:
             return retval
 
@@ -118,7 +123,7 @@ class GetExecutive(GetRequest):
                            .select(SystemVulnerabilities.cve_id.alias("cve_id_"),
                                    fn.Count(SystemVulnerabilities.id).alias("systems_affected_"))
                            .join(SystemPlatform, on=((SystemVulnerabilities.system_id == SystemPlatform.id) &
-                                                     system_is_active(rh_account_id=rh_account)))
+                                                     system_is_active(rh_account_id=rh_account, edge=edge)))
                            .where(SystemVulnerabilities.rh_account_id == rh_account)
                            .where(system_is_vulnerable())
                            .group_by(SystemVulnerabilities.cve_id))
@@ -196,7 +201,7 @@ class GetExecutive(GetRequest):
                                                         fn.COUNT(fn.Distinct(SystemVulnerabilities.system_id)).alias("systems_affected"))
                            .join(InsightsRule, on=(SystemVulnerabilities.rule_id == InsightsRule.id))
                            .join(SystemPlatform, on=((SystemVulnerabilities.system_id == SystemPlatform.id) &
-                                                     system_is_active(rh_account_id=rh_account)))
+                                                     system_is_active(rh_account_id=rh_account, edge=edge)))
                            .where(SystemVulnerabilities.rh_account_id == rh_account)
                            .where(system_has_rule_hit(rule_subselect=False))
                            .group_by(InsightsRule.rule_impact)
@@ -232,7 +237,7 @@ class GetExecutive(GetRequest):
                          .join(CveRuleMapping, on=(InsightsRule.id == CveRuleMapping.rule_id))
                          .join(CveMetadata, on=(CveRuleMapping.cve_id == CveMetadata.id))
                          .join(SystemPlatform, on=((SystemVulnerabilities.system_id == SystemPlatform.id) &
-                                                   system_is_active(rh_account_id=rh_account)))
+                                                   system_is_active(rh_account_id=rh_account, edge=edge)))
                          .where(SystemVulnerabilities.rh_account_id == rh_account)
                          .where(system_has_rule_hit())
                          .group_by(InsightsRule.name, InsightsRule.description_text, InsightsRule.rule_impact, InsightsRule.summary_text)

--- a/manager/vulnerabilities_handler.py
+++ b/manager/vulnerabilities_handler.py
@@ -193,7 +193,7 @@ class CvesListView(ListView):
                         fn.Sum(Case(None, ((SystemVulnerabilities.status_id != CveAccountData.status_id, 1),), 0)).alias("systems_status_divergent_"),
                         fn.Bool_Or(SystemVulnerabilities.advisory_available).alias("advisory_available_"))
                 .join(SystemPlatform, on=((SystemVulnerabilities.system_id == SystemPlatform.id) &
-                                          system_is_active(rh_account_id=rh_account_id)))
+                                          system_is_active(rh_account_id=rh_account_id, edge=edge_feature_arg())))
                 .join(CveAccountData, JOIN.LEFT_OUTER, on=((SystemVulnerabilities.cve_id == CveAccountData.cve_id)
                                                            & (CveAccountData.rh_account_id == rh_account_id)))
                 .where(SystemVulnerabilities.rh_account_id == rh_account_id)
@@ -213,7 +213,7 @@ class CvesListView(ListView):
                                 Value(0).alias("systems_status_divergent_"),
                                 Value(False).alias("advisory_available_"))
                         .join(SystemPlatform, on=((SystemVulnerablePackage.system_id == SystemPlatform.id) &
-                                                  system_is_active(rh_account_id=rh_account_id)))
+                                                  system_is_active(rh_account_id=rh_account_id, edge=edge_feature_arg())))
                         .join(VulnerablePackageCVE, on=((SystemVulnerablePackage.vulnerable_package_id == VulnerablePackageCVE.vulnerable_package_id)))
                         .where(SystemVulnerablePackage.rh_account_id == rh_account_id)
                         .group_by(VulnerablePackageCVE.cve_id))
@@ -302,7 +302,7 @@ class GetCves(GetRequest):
         res["links"] = cves_view.get_pagination_links()
         res["data"] = cls._format_data(list_arguments["data_format"], cls.assign_cves(cves_view), ids_only=cls._ids_only)
 
-        res["meta"]["system_count"] = get_system_count(rh_account_id)
+        res["meta"]["system_count"] = get_system_count(rh_account_id, edge=edge_feature_arg())
         res["meta"]["cves_without_errata"] = cves_without_errata
         return res
 

--- a/manager/vulnerabilities_handler.py
+++ b/manager/vulnerabilities_handler.py
@@ -13,6 +13,7 @@ from .base import cyndi_join
 from .base import DEFAULT_BUSINESS_RISK
 from .base import DEFAULT_STATUS
 from .base import DISABLE_ACCOUNT_CACHE
+from .base import edge_feature_arg
 from .base import get_account_data
 from .base import get_rules_for_cves
 from .base import get_system_count
@@ -321,7 +322,7 @@ class GetCves(GetRequest):
         else:
             impact_id_map = _prepare_impact_id_map()
             cves_materialized = list(cves_view)  # execute query
-            rules_map = get_rules_for_cves([row["cve_id"] for row in cves_materialized])
+            rules_map = get_rules_for_cves([row["cve_id"] for row in cves_materialized], edge=edge_feature_arg())
             for row in cves_materialized:
                 entry = dict()
                 res = {}

--- a/tests/manager_tests/conftest.py
+++ b/tests/manager_tests/conftest.py
@@ -12,6 +12,7 @@ from ..utils import restore_db
 from ..utils import truncate_db_version
 from common import database_handler
 from common import peewee_database
+from common.feature_flags import UNLEASH
 
 peewee_database.DB = PostgresqlDatabase(None)
 
@@ -70,3 +71,32 @@ def pg_db_conn(pg_db_mod):
     conn = psycopg2.connect(**pg_db_mod.dsn())
     yield conn
     conn.close()
+
+
+@pytest.fixture(autouse=True)
+def mock_feature_flags(request, monkeypatch):
+    """
+    Adds support for feature flag marks with @pytest.mark.feature_flag("feature").
+    If a feature flag isn't marked, then it defaults to False or to fallback_function
+
+    Examples:
+
+        @pytest.mark.feature_flag("feature_one") -- enables feature_one
+        @pytest.mark.feature_flag("feature_two", False) -- disables feature_two
+
+    """
+    feature_flags = [flag for flag in request.node.iter_markers("feature_flag")]
+    if not feature_flags:
+        return
+
+    def feature_is_enabled(feature_name, context=None, fallback_function=None):
+        flag = next((flag for flag in feature_flags if flag.args[0] == feature_name), None)
+        if not flag:
+            if fallback_function:
+                return fallback_function(feature_name, context)
+            else:
+                return False
+
+        return True if len(flag.args) == 1 else flag[1]
+
+    monkeypatch.setattr(UNLEASH, "is_enabled", feature_is_enabled)

--- a/tests/manager_tests/test_dashbar_handler.py
+++ b/tests/manager_tests/test_dashbar_handler.py
@@ -1,7 +1,10 @@
 """
 Dashbar tests
 """
+import pytest
+
 from .vuln_testcase import FlaskTestCase
+from common.feature_flags import EDGE_PARITY_FEATURE
 
 
 class TestDashbarHandler(FlaskTestCase):
@@ -13,6 +16,15 @@ class TestDashbarHandler(FlaskTestCase):
         assert res.body.exploitable_cves == 2
         assert res.body.critical_cves == 3
         assert res.body.cves_with_rule == 4
+        assert res.body.important_cves == 4
+
+    @pytest.mark.feature_flag(EDGE_PARITY_FEATURE)
+    def test_dashbar_with_edge(self):
+        """Test dashbar with edge systems included"""
+        res = self.vfetch("dashbar").check_response()
+        assert res.body.exploitable_cves == 2
+        assert res.body.critical_cves == 3
+        assert res.body.cves_with_rule == 5
         assert res.body.important_cves == 4
 
     def test_dashbar_tags(self):

--- a/tests/manager_tests/test_dashboard_handler.py
+++ b/tests/manager_tests/test_dashboard_handler.py
@@ -1,6 +1,9 @@
 """Unit tests for report handler"""
 # pylint: disable=missing-docstring
+import pytest
+
 from .vuln_testcase import FlaskTestCase
+from common.feature_flags import EDGE_PARITY_FEATURE
 
 
 class TestDashboardHandler(FlaskTestCase):
@@ -13,6 +16,17 @@ class TestDashboardHandler(FlaskTestCase):
         assert report.body.cves_by_severity["8to10"]["count"] == 2
         assert report.body.cves_by_severity["na"]["count"] == 1
         assert report.body.rules_cves_total == 4
+
+    @pytest.mark.feature_flag(EDGE_PARITY_FEATURE)
+    def test_dashboard_with_edge(self):
+        report = self.vfetch("dashboard").check_response()
+        assert report.body.cves_total == 10
+        assert report.body.cves_by_severity["0to3.9"]["count"] == 0
+        assert report.body.cves_by_severity["4to7.9"]["count"] == 7
+        assert report.body.cves_by_severity["4to7.9"]["known_exploits"] == 2
+        assert report.body.cves_by_severity["8to10"]["count"] == 2
+        assert report.body.cves_by_severity["na"]["count"] == 1
+        assert report.body.rules_cves_total == 5
 
     def test_dashboard_tags(self):
         report = self.vfetch("dashboard?tags=vulnerability/usage=NAS").check_response()

--- a/tests/manager_tests/test_report_handler.py
+++ b/tests/manager_tests/test_report_handler.py
@@ -2,7 +2,10 @@
 # pylint: disable=missing-docstring,too-many-public-methods,invalid-name
 import json
 
+import pytest
+
 from .vuln_testcase import FlaskTestCase
+from common.feature_flags import EDGE_PARITY_FEATURE
 
 
 DEFAULT_RETVAL = {
@@ -36,6 +39,20 @@ class TestReportHandler(FlaskTestCase):
         assert report.body.top_cves[0].synopsis == "CVE-2018-3"
         assert report.body.top_cves[0].systems_affected == 1
         assert report.body.top_cves[0].cvss3_score == "9.900"
+        assert (
+            report.body.rules_total
+            == 5
+            == sum([report.body.rules_by_severity[item]["rule_count"] for item in report.body.rules_by_severity])
+        )
+        assert report.body.top_rules[0].systems_affected == 2
+        assert report.body.top_rules[1].systems_affected == 2
+        assert report.body.top_rules[2].systems_affected == 1
+
+    @pytest.mark.feature_flag(EDGE_PARITY_FEATURE)
+    def test_executive_report_with_edge(self):
+        report = self.vfetch("report/executive").check_response()
+        assert report.body.system_count == 20
+        assert report.body.cves_total == 10
         assert (
             report.body.rules_total
             == 5

--- a/tests/manager_tests/test_vulnerabilities_handler.py
+++ b/tests/manager_tests/test_vulnerabilities_handler.py
@@ -3,6 +3,7 @@
 import pytest
 
 from .vuln_testcase import FlaskTestCase
+from common.feature_flags import EDGE_PARITY_FEATURE
 
 IMPACTS = {"Critical": 3, "Important": 2, "Moderate": 1, "Low": 0}
 SORT_BY = (
@@ -22,6 +23,11 @@ class TestVulnerabilitiesHandler(FlaskTestCase):
         response = self.vfetch("vulnerabilities/cves?affecting=true").check_response()
         response2 = self.vfetch("vulnerabilities/cves/ids?affecting=true").check_response()
         assert len(response.body.data) == len(response2.body.data) == 15
+
+    @pytest.mark.feature_flag(EDGE_PARITY_FEATURE)
+    def test_vulnerabilities_cves_edge_included(self):
+        response = self.vfetch("vulnerabilities/cves?affecting=true").check_response()
+        assert response.body.meta.system_count == 20
 
     @pytest.mark.parametrize("value,expected", IMPACT_FILTER, ids=[x[0] for x in IMPACT_FILTER])
     def test_vulnerabilities_impact_filter(self, value, expected):


### PR DESCRIPTION
Creates `vulnerability.edge_parity` feature flag.
If enabled, edge systems are counted in major API responses counting affected systems (or systems affected by a rule).

VULN-2776
VULN-2765

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
