### PR TITLE
feat(listener): skip non-rhel systems

### DIFF
--- a/common/config.py
+++ b/common/config.py
@@ -156,6 +156,9 @@ class BaseConfig:
         # Reporters
         self.allowed_reporters = os.getenv("ALLOWED_REPORTERS", "puptoo,rhsm-system-profile-bridge").split(",")
 
+        # OSes
+        self.allowed_oses = set(os.getenv("ALLOWED_OSES", "RHEL").split(","))
+
         # Inventory Groups
         self.disable_inventory_groups = strtobool(os.getenv("DISABLE_INVENTORY_GROUPS", "FALSE"))
 

--- a/conf/listener.env
+++ b/conf/listener.env
@@ -5,3 +5,4 @@ KAFKA_GROUP_ID=vulnerability-listener2
 MAX_LOADED_LISTENER_MSGS=50
 ADVISOR_RESULTS_TOPIC=platform.engine.results
 MESSAGE_TOPIC=vulnerability.evaluator.upload
+ALLOWED_OSES=RHEL

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -343,6 +343,8 @@ objects:
           value: ${MAX_LOADED_LISTENER_MSGS}
         - name: ALLOWED_REPORTERS
           value: ${ALLOWED_REPORTERS}
+        - name: ALLOWED_OSES
+          value: ${ALLOWED_OSES}
         resources:
           limits:
             cpu: ${{CPU_LIMIT_LISTENER}}
@@ -1032,3 +1034,5 @@ parameters:
   value: 200m
 - name: FLOORIST_CPU_LIMIT
   value: 500m
+- name: ALLOWED_OSES
+  value: "RHEL"

--- a/listener/listener.py
+++ b/listener/listener.py
@@ -112,11 +112,18 @@ class AdvisorMsgValidator:
         """Constructor"""
         self.payload_tracker = payload_tracker
 
+    def _validate_os_version(self, msg: dict):
+        """Validate if the advisor message system does have correct OS"""
+        if not msg.get("input", {}).get("host", {}).get("system_profile", {}).get("operating_system", {}).get("name") in CFG.allowed_oses:
+            SKIPPED_MESSAGES.inc()
+            raise InvalidInventoryMsg("advisor message does not contain valid operating system")
+
     def validate_message(self, msg: dict):
         """Validates message and returns result, also increments prometheus counters"""
         if not validate_kafka_msg(msg, self._required_msg_fields):
             SKIPPED_MESSAGES.inc()
             raise InvalidAdvisorMsg("advisor message does not contain expected fields")
+        self._validate_os_version(msg)
 
 
 class Listener:

--- a/listener/listener.py
+++ b/listener/listener.py
@@ -80,14 +80,22 @@ class InventoryMsgValidator:
             SKIPPED_MESSAGES.inc()
             raise InvalidInventoryMsg("inventory deleted message does not contain expected fields")
 
+    def _validate_os_version(self, msg: dict):
+        """Validates if the inventory message system does have correct OS"""
+        if not msg.get("host", {}).get("system_profile", {}).get("operating_system", {}).get("name") in CFG.allowed_oses:
+            SKIPPED_MESSAGES.inc()
+            raise InvalidInventoryMsg("inventory message does not contain valid operating system")
+
     def validate_message(self, msg: dict) -> InventoryMsgType:
         """Validate inventory message, returns its type. Increments
         prometheus counters"""
         if msg.get("type") == "created":
             self._validate_created_updated(msg)
+            self._validate_os_version(msg)
             return InventoryMsgType.CREATED
         if msg.get("type") == "updated":
             self._validate_created_updated(msg)
+            self._validate_os_version(msg)
             return InventoryMsgType.UPDATED
         if msg.get("type") == "delete":
             self._validate_deleted(msg)

--- a/platform_mock/platform_mock.py
+++ b/platform_mock/platform_mock.py
@@ -146,7 +146,8 @@ class UploadHandler(BaseHandler):
                                            "installed_packages": profile["installed_packages"],
                                            "yum_repos": [{"id": r, "name": r, "enabled": True} for r in profile["yum_repos"]],
                                            "dnf_modules": profile["dnf_modules"],
-                                           "insights_client_version": "3.0.13-1"},
+                                           "insights_client_version": "3.0.13-1",
+                                           "operating_system": {"name": "RHEL", "major": 8, "minor": 0}},
                                        "reporter": self._get_reporter()
                                        },
                               "platform_metadata": {"request_id": str(uuid.uuid1()), "url": download_url,


### PR DESCRIPTION
I downgraded the insights-core, because it wont work with the newest version, the `system_profile` method is not called with system metadata but none in which the listener kafka message ends up with empty fields.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
