### PR TITLE
fix(manager): always join with inventory.hosts even if there are no args

### DIFF
--- a/manager/dashbar_handler.py
+++ b/manager/dashbar_handler.py
@@ -87,9 +87,8 @@ class GetDashbar(GetRequest):
                      .where(SystemVulnerabilities.rh_account_id == rh_account)
                      .where(system_is_vulnerable())
                      .where(CveMetadata.advisories_list != SQL("'[]'")))
-            if cyndi_request:
-                query = cyndi_join(query)
-                query = apply_filters(query, args, filters, {})
+            query = cyndi_join(query)
+            query = apply_filters(query, args, filters, {})
         res = query.first()
 
         return {"exploitable_cves": res.exploitable_cves,

--- a/manager/dashboard_handler.py
+++ b/manager/dashboard_handler.py
@@ -120,9 +120,8 @@ class GetDashboard(GetRequest):
                                                               system_is_active(rh_account_id=rh_account, edge=edge)))
                                     .where(SystemVulnerabilities.rh_account_id == rh_account)
                                     .where(system_is_vulnerable()))
-            if cyndi_request:
-                active_cves_subquery = cyndi_join(active_cves_subquery)
-                active_cves_subquery = apply_filters(active_cves_subquery, args, FILTERS, {})
+            active_cves_subquery = cyndi_join(active_cves_subquery)
+            active_cves_subquery = apply_filters(active_cves_subquery, args, FILTERS, {})
 
         query = (CveMetadata
                  .select(CveMetadata.cve,
@@ -209,9 +208,8 @@ class GetDashboard(GetRequest):
                             .where(SystemVulnerabilities.rh_account_id == rh_account)
                             .where(system_has_rule_hit())
                             .group_by(SystemVulnerabilities.rule_id))
-            if cyndi_request:
-                counts_query = cyndi_join(counts_query)
-                counts_query = apply_filters(counts_query, args, FILTERS, {})
+            counts_query = cyndi_join(counts_query)
+            counts_query = apply_filters(counts_query, args, FILTERS, {})
 
         recent_rules = (InsightsRule.select(InsightsRule.description_text.alias("name"),
                                             InsightsRule.summary_text.alias("description"),


### PR DESCRIPTION
some extra systems (e.g. centos) can persist in system_platform

and also because of inventory groups

VULN-2791

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
