### PR TITLE
fix(manager): apply non-empty advisories list filter consistently in all APIs

### DIFF
--- a/manager/dashbar_handler.py
+++ b/manager/dashbar_handler.py
@@ -55,7 +55,7 @@ class GetDashbar(GetRequest):
         cyndi_request = is_not_cacheable_request(args)
         filters = [filter_types.SYSTEM_TAGS, filter_types.SYSTEM_SAP, filter_types.SYSTEM_SAP_SIDS, filter_types.SYSTEM_AAP, filter_types.SYSTEM_MSSQL]
 
-        rh_account, cve_cache_from, cve_cache_keepalive, _ = get_account_data(connexion.context["user"])
+        rh_account, cve_cache_from, cve_cache_keepalive, cves_without_errata = get_account_data(connexion.context["user"])
         update_cve_cache_keepalive(rh_account, cve_cache_keepalive)
 
         if not DISABLE_ACCOUNT_CACHE and not cyndi_request and cve_cache_from:
@@ -85,8 +85,9 @@ class GetDashbar(GetRequest):
                      .join(SystemPlatform, on=((SystemVulnerabilities.system_id == SystemPlatform.id) &
                                                system_is_active(rh_account_id=rh_account, edge=edge_feature_arg())))
                      .where(SystemVulnerabilities.rh_account_id == rh_account)
-                     .where(system_is_vulnerable())
-                     .where(CveMetadata.advisories_list != SQL("'[]'")))
+                     .where(system_is_vulnerable()))
+            if not cves_without_errata:
+                query = query.where(CveMetadata.advisories_list != SQL("'[]'"))
             query = cyndi_join(query)
             query = apply_filters(query, args, filters, {})
         res = query.first()

--- a/manager/dashboard_handler.py
+++ b/manager/dashboard_handler.py
@@ -98,7 +98,7 @@ class GetDashboard(GetRequest):
         ]
         args = cls._parse_arguments(kwargs, args_desc)
         cyndi_request = is_not_cacheable_request(args)
-        rh_account, cve_cache_from, cve_cache_keepalive, _ = get_account_data(connexion.context["user"])
+        rh_account, cve_cache_from, cve_cache_keepalive, cves_without_errata = get_account_data(connexion.context["user"])
 
         # argument for controling host types in system counts
         edge = edge_feature_arg()
@@ -131,8 +131,9 @@ class GetDashboard(GetRequest):
                          CveMetadata.exploit_data,
                          CveMetadata.advisories_list)
                  .join(active_cves_subquery, on=(CveMetadata.id == active_cves_subquery.c.cve_id_))
-                 .where(CveMetadata.advisories_list != SQL("'[]'"))
                  .dicts())
+        if not cves_without_errata:
+            query = query.where(CveMetadata.advisories_list != SQL("'[]'"))
 
         cve_data = []
         affecting_cves = []

--- a/manager/report_handler.py
+++ b/manager/report_handler.py
@@ -98,7 +98,7 @@ class GetExecutive(GetRequest):
             "top_cves": [],
             "top_rules": [],
         }
-        rh_account, cve_cache_from, cve_cache_keepalive, _ = get_account_data(connexion.context["user"])
+        rh_account, cve_cache_from, cve_cache_keepalive, cves_without_errata = get_account_data(connexion.context["user"])
         if rh_account is None:
             return retval
 
@@ -134,8 +134,9 @@ class GetExecutive(GetRequest):
                              fn.COALESCE(CveMetadata.cvss3_score, CveMetadata.cvss2_score).alias("cvss_score"),
                              CveMetadata.public_date, CveMetadata.exploit_data, CveMetadata.advisories_list)
                      .join(count_query, JOIN.INNER, on=(CveMetadata.id == count_query.c.cve_id_))
-                     .where(CveMetadata.advisories_list != SQL("'[]'"))
                      .dicts())
+        if not cves_without_errata:
+            cve_query = cve_query.where(CveMetadata.advisories_list != SQL("'[]'"))
 
         cve_data = [(cve["cvss_score"], cve["public_date"], cve["exploit_data"], cve["advisories_list"]) for cve in cve_query]
 
@@ -186,15 +187,15 @@ class GetExecutive(GetRequest):
         # systems if there are not 3 CVE in the 8 to 10 range, then it looks for CVEs in 4 to 8 range, sorted by a
         # number of systems affected. The high-end range check is exclusive that is why 11 here.
         cves_limit = 3
-        top_cves = cls._get_top_cves_by_cvss(8.0, 11, count_query, limit=cves_limit)
+        top_cves = cls._get_top_cves_by_cvss(8.0, 11, count_query, cves_without_errata, limit=cves_limit)
         cls._build_top_cves(top_cves, retval)
         cves_count = top_cves.count()
         if cves_count < cves_limit:
-            next_tier_top = cls._get_top_cves_by_cvss(4.0, 8.0, count_query, limit=cves_limit - cves_count)
+            next_tier_top = cls._get_top_cves_by_cvss(4.0, 8.0, count_query, cves_without_errata, limit=cves_limit - cves_count)
             cls._build_top_cves(next_tier_top, retval)
             next_cves_count = next_tier_top.count()
             if next_cves_count < (cves_limit - cves_count):
-                last_tier_top = cls._get_top_cves_by_cvss(0.0, 4.0, count_query, limit=cves_limit - (cves_count + next_cves_count))
+                last_tier_top = cls._get_top_cves_by_cvss(0.0, 4.0, count_query, cves_without_errata, limit=cves_limit - (cves_count + next_cves_count))
                 cls._build_top_cves(last_tier_top, retval)
 
         rules_breakdown = (SystemVulnerabilities.select(fn.COUNT(fn.Distinct(InsightsRule.id)).alias("rule_count"), InsightsRule.rule_impact.alias("severity"),
@@ -252,7 +253,7 @@ class GetExecutive(GetRequest):
         return retval
 
     @staticmethod
-    def _get_top_cves_by_cvss(cvss_from, cvss_to, count_query, limit=3):
+    def _get_top_cves_by_cvss(cvss_from, cvss_to, count_query, cves_without_errata, limit=3):
         # pylint: disable=singleton-comparison
         rules = (CveRuleMapping.select(CveRuleMapping.cve_id, CveRuleMapping.rule_id)
                  .join(InsightsRule, on=((CveRuleMapping.rule_id == InsightsRule.id) & (InsightsRule.active == True))))
@@ -268,9 +269,10 @@ class GetExecutive(GetRequest):
                            fn.COALESCE(CveMetadata.cvss3_score, CveMetadata.cvss2_score).desc(nulls="LAST"), CveMetadata.cve, CveMetadata.id)
                  .group_by(CveMetadata.id, CveMetadata.cve, CveMetadata.cvss3_score, CveMetadata.cvss2_score,
                            CveMetadata.description, count_query.c.systems_affected_.alias("systems_affected"))
-                 .where(CveMetadata.advisories_list != SQL("'[]'"))
                  .limit(limit)
                  .dicts())
+        if not cves_without_errata:
+            query = query.where(CveMetadata.advisories_list != SQL("'[]'"))
         return query
 
     @classmethod

--- a/tests/manager_tests/test_dashbar_handler.py
+++ b/tests/manager_tests/test_dashbar_handler.py
@@ -14,34 +14,34 @@ class TestDashbarHandler(FlaskTestCase):
         """Test dashbar"""
         res = self.vfetch("dashbar").check_response()
         assert res.body.exploitable_cves == 2
-        assert res.body.critical_cves == 3
-        assert res.body.cves_with_rule == 4
-        assert res.body.important_cves == 4
+        assert res.body.critical_cves == 5
+        assert res.body.cves_with_rule == 7
+        assert res.body.important_cves == 6
 
     @pytest.mark.feature_flag(EDGE_PARITY_FEATURE)
     def test_dashbar_with_edge(self):
         """Test dashbar with edge systems included"""
         res = self.vfetch("dashbar").check_response()
         assert res.body.exploitable_cves == 2
-        assert res.body.critical_cves == 3
-        assert res.body.cves_with_rule == 5
-        assert res.body.important_cves == 4
+        assert res.body.critical_cves == 5
+        assert res.body.cves_with_rule == 8
+        assert res.body.important_cves == 6
 
     def test_dashbar_tags(self):
         """Test dashbar with tags filter"""
         res = self.vfetch("dashbar?tags=vulnerability/usage=NAS").check_response()
         assert res.body.exploitable_cves == 2
-        assert res.body.critical_cves == 0
-        assert res.body.cves_with_rule == 4
-        assert res.body.important_cves == 4
+        assert res.body.critical_cves == 1
+        assert res.body.cves_with_rule == 7
+        assert res.body.important_cves == 6
 
     def test_dashbar_sap_system(self):
         """Test dashbar with sap systems"""
         res = self.vfetch("dashbar?sap_system=true").check_response()
         assert res.body.exploitable_cves == 2
-        assert res.body.critical_cves == 3
-        assert res.body.cves_with_rule == 4
-        assert res.body.important_cves == 4
+        assert res.body.critical_cves == 5
+        assert res.body.cves_with_rule == 7
+        assert res.body.important_cves == 6
 
     def test_dashbar_sap_ids(self):
         """Test dashbar with sap ids"""

--- a/tests/manager_tests/test_dashboard_handler.py
+++ b/tests/manager_tests/test_dashboard_handler.py
@@ -9,54 +9,54 @@ from common.feature_flags import EDGE_PARITY_FEATURE
 class TestDashboardHandler(FlaskTestCase):
     def test_dashboard(self):
         report = self.vfetch("dashboard").check_response()
-        assert report.body.cves_total == 9
+        assert report.body.cves_total == 15
         assert report.body.cves_by_severity["0to3.9"]["count"] == 0
-        assert report.body.cves_by_severity["4to7.9"]["count"] == 6
+        assert report.body.cves_by_severity["4to7.9"]["count"] == 8
         assert report.body.cves_by_severity["4to7.9"]["known_exploits"] == 2
-        assert report.body.cves_by_severity["8to10"]["count"] == 2
-        assert report.body.cves_by_severity["na"]["count"] == 1
-        assert report.body.rules_cves_total == 4
+        assert report.body.cves_by_severity["8to10"]["count"] == 5
+        assert report.body.cves_by_severity["na"]["count"] == 2
+        assert report.body.rules_cves_total == 7
 
     @pytest.mark.feature_flag(EDGE_PARITY_FEATURE)
     def test_dashboard_with_edge(self):
         report = self.vfetch("dashboard").check_response()
-        assert report.body.cves_total == 10
+        assert report.body.cves_total == 16
         assert report.body.cves_by_severity["0to3.9"]["count"] == 0
-        assert report.body.cves_by_severity["4to7.9"]["count"] == 7
+        assert report.body.cves_by_severity["4to7.9"]["count"] == 9
         assert report.body.cves_by_severity["4to7.9"]["known_exploits"] == 2
-        assert report.body.cves_by_severity["8to10"]["count"] == 2
-        assert report.body.cves_by_severity["na"]["count"] == 1
-        assert report.body.rules_cves_total == 5
+        assert report.body.cves_by_severity["8to10"]["count"] == 5
+        assert report.body.cves_by_severity["na"]["count"] == 2
+        assert report.body.rules_cves_total == 8
 
     def test_dashboard_tags(self):
         report = self.vfetch("dashboard?tags=vulnerability/usage=NAS").check_response()
-        assert report.body.cves_total == 5
+        assert report.body.cves_total == 9
         assert report.body.cves_by_severity["0to3.9"]["count"] == 0
-        assert report.body.cves_by_severity["4to7.9"]["count"] == 4
+        assert report.body.cves_by_severity["4to7.9"]["count"] == 5
         assert report.body.cves_by_severity["4to7.9"]["known_exploits"] == 2
-        assert report.body.cves_by_severity["8to10"]["count"] == 0
-        assert report.body.cves_by_severity["na"]["count"] == 1
-        assert report.body.rules_cves_total == 4
+        assert report.body.cves_by_severity["8to10"]["count"] == 2
+        assert report.body.cves_by_severity["na"]["count"] == 2
+        assert report.body.rules_cves_total == 7
 
     def test_dashboard_sap_system(self):
         report = self.vfetch("dashboard?sap_system=true").check_response()
-        assert report.body.cves_total == 9
+        assert report.body.cves_total == 15
         assert report.body.cves_by_severity["0to3.9"]["count"] == 0
-        assert report.body.cves_by_severity["4to7.9"]["count"] == 6
+        assert report.body.cves_by_severity["4to7.9"]["count"] == 8
         assert report.body.cves_by_severity["4to7.9"]["known_exploits"] == 2
-        assert report.body.cves_by_severity["8to10"]["count"] == 2
-        assert report.body.cves_by_severity["na"]["count"] == 1
-        assert report.body.rules_cves_total == 4
+        assert report.body.cves_by_severity["8to10"]["count"] == 5
+        assert report.body.cves_by_severity["na"]["count"] == 2
+        assert report.body.rules_cves_total == 7
 
     def test_dashboard_sap_system_and_tags(self):  # pylint: disable=invalid-name
         report = self.vfetch("dashboard?sap_system=true&tags=vulnerability/usage=server").check_response()
-        assert report.body.cves_total == 8
+        assert report.body.cves_total == 12
         assert report.body.cves_by_severity["0to3.9"]["count"] == 0
-        assert report.body.cves_by_severity["4to7.9"]["count"] == 6
+        assert report.body.cves_by_severity["4to7.9"]["count"] == 8
         assert report.body.cves_by_severity["4to7.9"]["known_exploits"] == 2
-        assert report.body.cves_by_severity["8to10"]["count"] == 2
+        assert report.body.cves_by_severity["8to10"]["count"] == 4
         assert report.body.cves_by_severity["na"]["count"] == 0
-        assert report.body.rules_cves_total == 4
+        assert report.body.rules_cves_total == 6
 
     def test_dashboard_sap_sid(self):
         report = self.vfetch("dashboard?sap_sids=xxee").check_response()

--- a/tests/manager_tests/test_report_handler.py
+++ b/tests/manager_tests/test_report_handler.py
@@ -35,9 +35,9 @@ class TestReportHandler(FlaskTestCase):
     def test_executive_report(self):
         report = self.vfetch("report/executive").check_response()
         assert report.body.system_count == 18
-        assert report.body.cves_total == 9
-        assert report.body.top_cves[0].synopsis == "CVE-2018-3"
-        assert report.body.top_cves[0].systems_affected == 1
+        assert report.body.cves_total == 15
+        assert report.body.top_cves[0].synopsis == "CVE-2017-1"
+        assert report.body.top_cves[0].systems_affected == 3
         assert report.body.top_cves[0].cvss3_score == "9.900"
         assert (
             report.body.rules_total
@@ -52,7 +52,7 @@ class TestReportHandler(FlaskTestCase):
     def test_executive_report_with_edge(self):
         report = self.vfetch("report/executive").check_response()
         assert report.body.system_count == 20
-        assert report.body.cves_total == 10
+        assert report.body.cves_total == 16
         assert (
             report.body.rules_total
             == 5


### PR DESCRIPTION
like it's filtered in /vulnerabilities/cves API

this is a workaround for discrepancies in CVE data causing incorrect counts between different endpoints some fixable CVE like CVE-2018-20217 has empty advisory list even if it shouldn't have

this should be fixed properly later (the exclusion based on empty advisories_list removed)

VULN-2791

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
