### PR TITLE
fix(manager): improve advisory_available without affecting filter

### DIFF
--- a/manager/filters.py
+++ b/manager/filters.py
@@ -175,6 +175,35 @@ def _filter_cve_by_status(query, args, _kwargs):
     return query
 
 
+def _filter_cve_by_advisory_available(query, args, kwargs):
+    """
+    Filters list of CVEs based on advisory availability. Query has to contain CveMetadata table.
+
+    Args:
+        query (object): Query object to apply filters to
+        args (dict): Query arguemnts
+
+    Returns:
+        object: Modified query with CVE status filter applied
+    """
+    if "advisory_available" in args and args["advisory_available"] is not None:
+        count_subquery = kwargs["count_subquery"]
+
+        def bool_expr(presence_bool):
+            if presence_bool:
+                return (CveMetadata.advisories_list != SQL("'[]'")) | \
+                    ((fn.COALESCE(count_subquery.c.systems_affected_rpmdnf_, 0) + fn.COALESCE(count_subquery.c.systems_affected_edge_, 0)) != 0)
+            return (CveMetadata.advisories_list == SQL("'[]'")) | \
+                ((fn.COALESCE(count_subquery.c.systems_affected_rpmdnf_, 0) + fn.COALESCE(count_subquery.c.systems_affected_edge_, 0)) == 0)
+
+        if True in args["advisory_available"] and False in args["advisory_available"]:
+            return query
+
+        query = query.where(bool_expr(args["advisory_available"][0]))
+
+    return query
+
+
 def _filter_system_by_uuid(query, args, _kwargs):
     """
     Filters list of systems based on their UUID. Query has to contain SystemPlatform table.
@@ -666,6 +695,7 @@ class filter_types(Enum):  # pylint: disable=invalid-name
     CVE_RULE_PRESENCE = _filter_cve_by_rule_presence
     CVE_AFFECTING = _filter_cve_by_affecting
     CVE_STATUS = _filter_cve_by_status
+    CVE_ADVISORY_AVAILABLE = _filter_cve_by_advisory_available
     SYSTEM_CVE_RULE_KEY = _filter_system_cve_by_rule_key
     SYSTEM_CVE_RULE_PRESENCE = _filter_system_cve_by_rule_presence
     SYSTEM_CVE_RULE = _filter_system_cve_by_rule

--- a/manager/vulnerabilities_handler.py
+++ b/manager/vulnerabilities_handler.py
@@ -76,6 +76,7 @@ class CvesListView(ListView):
                               filter_types.CVE_AFFECTING,
                               filter_types.CVE_AFFECTING_HOST_TYPE,
                               filter_types.CVE_KNOWN_EXPLOITS,
+                              filter_types.CVE_ADVISORY_AVAILABLE,
                               ]
 
         subquery_filters = [filter_types.SYSTEM_TAGS,


### PR DESCRIPTION
VULN-2789

advisory_available=true,false or null:
display all CVEs

advisory_available=true:
display CVEs having at least 1 advisory + CVEs with advisories affecting current env (should be a subset but non necessarily due to rules)

advisory_available=false:
display CVEs having 0 advisory + CVEs marked as unfixed in current env

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
