### PR TITLE
fix(evaluator): set manual remediation for rule hits without playbook except

### DIFF
--- a/common/utils.py
+++ b/common/utils.py
@@ -320,7 +320,12 @@ def validate_cve_cache_keepalive(last_timestamp, threshold):
 
 
 def get_available_remediation_type(
-    advisory_available: bool, manually_fixable: bool, when_mitigated, mitigation_reason: str, playbook_count
+    advisory_available: bool,
+    manually_fixable: bool,
+    when_mitigated,
+    mitigation_reason: str,
+    playbook_count: int,
+    generate_autoplaybook: bool,
 ) -> int:
     """Get the best available remediation type considering both VMaaS and rule CVEs."""
     available_remediation = remediation.NONE.value
@@ -332,6 +337,12 @@ def get_available_remediation_type(
     if not mitigation_reason:  # CVE is active and reported from rules
         if playbook_count:
             available_remediation = max(remediation.PLAYBOOK.value, available_remediation)
+        elif generate_autoplaybook:
+            # No hand-crafted playbook available, mark vulnerability as Manual.
+            # Unless generate_autoplaybook is False (for cases like RHEL upgrade is required),
+            # there are usualy manual steps to fix or remediate the CVE in Resolution section
+            # This will be upgraded to Playbook remediation if package update is found by VMaaS
+            available_remediation = max(remediation.MANUAL.value, available_remediation)
     return available_remediation
 
 

--- a/evaluator/common.py
+++ b/evaluator/common.py
@@ -38,7 +38,7 @@ VMAAS_ERRORS_SKIP = Counter("ve_evaluator_vmaas_errors_skip", "# of evaluations 
 EMPTY_DATA_SKIP = Counter("ve_evaluator_data_skip", "# of evaluations skipped due to empty VMaaS json and rule results")
 
 # single member inside rule cache
-RuleCache = namedtuple("RuleCache", ["id", "playbook_count"])
+RuleCache = namedtuple("RuleCache", ["id", "playbook_count", "generate_autoplaybook"])
 # single member inside cve cache
 CveImpactCache = namedtuple("CveImpactCache", ["id"])
 # single member inside cve cache
@@ -106,6 +106,7 @@ class SystemVulnerabilitiesRow:
     rule_id: int
     rule_hit_details: str
     playbook_count: int
+    generate_autoplaybook: bool
     mitigation_reason: str
 
     remediation_type_id: int = -1
@@ -113,18 +114,24 @@ class SystemVulnerabilitiesRow:
     def _populate_remediation_type(self):
         """Populate the remediation type id field"""
         self.remediation_type_id = get_available_remediation_type(
-            self.advisory_available, self.manually_fixable, self.when_mitigated, self.mitigation_reason, self.playbook_count
+            self.advisory_available,
+            self.manually_fixable,
+            self.when_mitigated,
+            self.mitigation_reason,
+            self.playbook_count,
+            self.generate_autoplaybook,
         )
 
     def __post_init__(self):
         """Called after constructor"""
         self._populate_remediation_type()
 
-    def add_rule_info(self, rule_id: int, rule_hit_details: dict, playbook_count: int, mitigation_reason: str):
+    def add_rule_info(self, rule_id: int, rule_hit_details: dict, playbook_count: int, generate_autoplaybook: bool, mitigation_reason: str):
         """Add rule information to the vulnerability, used when vulnerability is upgraded from vmaas only to also rule"""
         self.rule_id = rule_id
         self.rule_hit_details = json.dumps(rule_hit_details)
         self.playbook_count = playbook_count
+        self.generate_autoplaybook = generate_autoplaybook
         self.mitigation_reason = mitigation_reason
         # need to regenerate remediation type id
         self._populate_remediation_type()

--- a/evaluator/logic.py
+++ b/evaluator/logic.py
@@ -82,9 +82,9 @@ class EvaluatorLogic:
         """Load rule cache from DB"""
         cache = {}
         async with conn.cursor(row_factory=dict_row) as cur:
-            await cur.execute("""SELECT id, name, playbook_count FROM insights_rule""")
+            await cur.execute("""SELECT id, name, playbook_count, generate_autoplaybook FROM insights_rule""")
             for rule in await cur.fetchall():
-                cache[rule["name"]] = RuleCache(rule["id"], rule["playbook_count"])
+                cache[rule["name"]] = RuleCache(rule["id"], rule["playbook_count"], rule["generate_autoplaybook"])
         return cache
 
     async def _load_package_name_cache(self) -> Dict[str, PackageNameCache]:
@@ -450,6 +450,7 @@ class EvaluatorLogic:
                 None,
                 None,
                 None,
+                None,
             )
 
         for cve_adv in manually_fixable_cves:
@@ -462,6 +463,7 @@ class EvaluatorLogic:
                 cve_adv.advisories,
                 True,
                 True,
+                None,
                 None,
                 None,
                 None,
@@ -518,7 +520,7 @@ class EvaluatorLogic:
         """Returns rule from cache, or inserts the rule into DB and cache"""
         if rule not in rule_cache:
             rule_id = await self._insert_rule(rule, rule_details["cves"].keys(), conn, rule_only=rule_only)
-            rule_cache[rule] = RuleCache(rule_id, None)
+            rule_cache[rule] = RuleCache(rule_id, None, None)
         return rule_cache
 
     async def _evaluate_advisor_res(
@@ -554,7 +556,9 @@ class EvaluatorLogic:
                 vulnerability.state = VulnerabilityState.VULNERABLE_BY_RULE_AND_PACKAGE
             elif vulnerability and mitigation_reason:
                 # system was vulnerable for cve from vmaas but not from by rules -> abnv
-                vulnerability.add_rule_info(rule_db.id, hit_details["details"], rule_db.playbook_count, mitigation_reason)
+                vulnerability.add_rule_info(
+                    rule_db.id, hit_details["details"], rule_db.playbook_count, rule_db.generate_autoplaybook, mitigation_reason
+                )
                 vulnerability.state = VulnerabilityState.VULNERABLE_BY_PACKAGE_NOT_RULE
             elif mitigation_reason:
                 # system is not vulnerable from vmaas nor rules
@@ -574,8 +578,9 @@ class EvaluatorLogic:
                     None,
                     None,
                     None,
+                    None,
                 )
-            vulnerability.add_rule_info(rule_db.id, hit_details["details"], rule_db.playbook_count, None)
+            vulnerability.add_rule_info(rule_db.id, hit_details["details"], rule_db.playbook_count, rule_db.generate_autoplaybook, None)
             sys_vuln_rows[cve] = vulnerability
 
         for cve, pass_details in rule_results["rule_passes"].items():
@@ -594,7 +599,11 @@ class EvaluatorLogic:
             rule_db = rule_cache[rule]
 
             package_vulnerability.add_rule_info(
-                rule_db.id, pass_details["details"], rule_db.playbook_count, pass_details["mitigation_reason"]
+                rule_db.id,
+                pass_details["details"],
+                rule_db.playbook_count,
+                rule_db.generate_autoplaybook,
+                pass_details["mitigation_reason"],
             )
             package_vulnerability.state = VulnerabilityState.VULNERABLE_BY_PACKAGE_NOT_RULE
             sys_vuln_rows[cve] = package_vulnerability


### PR DESCRIPTION
those flagged with generate_autoplaybook=false

Fixing a case when no hand-crafted playbook is available, mark vulnerability as Manual.
Unless generate_autoplaybook is False (for cases like RHEL upgrade is required),
there are usualy manual steps to fix or remediate the CVE in Resolution section
This will be upgraded to Playbook remediation if package update is found by VMaaS

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
