### PR TITLE
fix: store biggest latest_repo_change not just timestamp from last page

### DIFF
--- a/vmaas_sync/vmaas_sync.py
+++ b/vmaas_sync/vmaas_sync.py
@@ -184,12 +184,15 @@ def _fetch_vmaas_repos(modified_since: str) -> Dict[str, Any]:
     if not success:
         return {}
 
-    result = {}
+    result = {"latest_repo_change": None}
     repos = []
     for page in repos_pages:
         repos.extend(page["repository_list"].keys())
         result["last_change"] = page["last_change"]
-        result["latest_repo_change"] = parser.parse(page["latest_repo_change"]) if page["latest_repo_change"] else None
+        if page["latest_repo_change"]:
+            ts = parser.parse(page["latest_repo_change"])
+            if result["latest_repo_change"] is None or result["latest_repo_change"] < ts:
+                result["latest_repo_change"] = ts
     result["repos"] = repos
     LOGGER.info("Fetched %d repos, updated since %s", len(repos), modified_since)
     return result


### PR DESCRIPTION
vmaas shows latest_repo_change for the current page, so we need to store the latest timestamp, otherwise we are re-evaluating systems with the same repos
## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
