### PR TITLE
fix: workaround cve_cache issue with inventory groups

### DIFF
--- a/manager/base.py
+++ b/manager/base.py
@@ -683,9 +683,8 @@ def is_valid_cache(account_data: AccountData, group_ids: List[List[Dict[str, str
         # update keepalive
         to_update["cve_cache_keepalive"] = datetime.now(timezone.utc)
     if not _eq_sorted_groups(account_data.cve_cache_groups, group_ids):
-        # invalidate cache
-        to_update["cve_cache_groups"] = group_ids
-        to_update["cve_cache_from"] = None
+        # cached inventory groups are not valid for the current user
+        to_update["cve_cache_groups"] = []  # WORKAROUND: cache only full access to all system groups
         correct_groups = False
     if to_update:
         RHAccount.update(**to_update).where(RHAccount.id == account_data.id).execute()


### PR DESCRIPTION
When there are 2 users with different inventory groups in the same account, they can be invalidating cache for each other which will cause that api is slow for both of them. Cache only access to all inventory hosts. When a user doesn't have any inventory groups, then the query will be used without cache.

Stats from DB:
count of accounts | inventory groups
31581		  | []     // access to all hosts
1		  | [[]]   // access to ungrouped hosts only
6		  | access to only 1 inventory group
1		  | access to 1 group and to ungrouped hosts
1		  | access to multiple groups and ungrouped hosts

RHINENG-12465

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
