### PR TITLE
fix: add domain to allow download cve report to work in ITless

### DIFF
--- a/manager/base.py
+++ b/manager/base.py
@@ -64,7 +64,7 @@ DEFAULT_BUSINESS_RISK = "Not Defined"
 CVE_SYNOPSIS_SORT = [fn.SUBSTRING(SQL("cve_name"), r"-(\d+)-").cast("integer"),
                      fn.SUBSTRING(SQL("cve_name"), r"-(\d+)$").cast("integer")]
 
-UI_REFERER = re.compile("(.*).redhat.com|.openshiftusgov.com")
+UI_REFERER = re.compile("(.*).redhat.com|(.*).openshiftusgov.com")
 API_SOURCE = "API"
 UI_SOURCE = "UI"
 

--- a/manager/base.py
+++ b/manager/base.py
@@ -64,7 +64,7 @@ DEFAULT_BUSINESS_RISK = "Not Defined"
 CVE_SYNOPSIS_SORT = [fn.SUBSTRING(SQL("cve_name"), r"-(\d+)-").cast("integer"),
                      fn.SUBSTRING(SQL("cve_name"), r"-(\d+)$").cast("integer")]
 
-UI_REFERER = re.compile("(.*).redhat.com")
+UI_REFERER = re.compile("(.*).redhat.com|.openshiftusgov.com")
 API_SOURCE = "API"
 UI_SOURCE = "UI"
 


### PR DESCRIPTION
in ITless env the`report by CVEs` (/vulnerability/reports) was broken as it has a different domain

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
