### PR TITLE
fix(build): add build arg ALT_REPO for runtimeimg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ RUN pip3.12 install --upgrade pip && \
 # -------------
 # runtime image
 FROM ${RUNIMG} AS runtimeimg
+ARG ALT_REPO
 
 RUN (microdnf module enable -y postgresql:16 || curl -o /etc/yum.repos.d/postgresql.repo $ALT_REPO) && \
     microdnf install -y --setopt=install_weak_deps=0 --setopt=tsflags=nodocs \


### PR DESCRIPTION
## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices

## Summary by Sourcery

Add a build argument ALT_REPO to the Dockerfile runtime image stage and use it to specify a fallback PostgreSQL repository URL during build

Build:
- Introduce ALT_REPO build argument in Dockerfile for the runtime image
- Use ALT_REPO to download a PostgreSQL YUM repo file when module enable fails