### PR TITLE
fix(taskomatic): add run for exploit_sync

### DIFF
--- a/exploit_sync/exploit_sync.py
+++ b/exploit_sync/exploit_sync.py
@@ -78,6 +78,11 @@ def sync_exploits():
     LOGGER.info("Finished exploit sync job")
 
 
-if __name__ == "__main__":
+def run():
+    """Taskomatic job for syncing Exploits"""
     init_logging()
     sync_exploits()
+
+
+if __name__ == "__main__":
+    run()


### PR DESCRIPTION
Requires envs:
```
JOBS=exploit_sync:240
JOBS_STARTUP=exploit_sync
IS_FEDRAMP=true
```

Logs
```
15:29:25,034:INFO:__main__:Adding job: exploit_sync, cadence each 240 minutes, run on startup: True
15:29:25,035:INFO:.taskomatic.jobs.cacheman:Started cacheman job.
15:29:25,036:INFO:.taskomatic.jobs.exploit_sync:Starting exploit sync job
15:29:25,036:INFO:.taskomatic.jobs.exploit_sync:FedRAMP env, loading exploits from static repo.
15:29:25,075:INFO:.taskomatic.jobs.exploit_sync:Finished exploit sync job
```

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices

## Summary by Sourcery

Add a run() entry point for the exploit_sync job to support taskomatic scheduling.

Enhancements:
- Introduce run() function wrapping init_logging and sync_exploits as the taskomatic job entry point
- Update __main__ block to call run() instead of inline logic