### PR TITLE
feat(vmaas_sync): resiliency on latest_repo_change

### DIFF
--- a/vmaas_sync/vmaas_sync.py
+++ b/vmaas_sync/vmaas_sync.py
@@ -253,7 +253,7 @@ def _fetch_vmaas_repos(modified_since: str) -> Dict[str, Any]:
                 updated_package_names.update(repo_detail["updated_package_names"])
             repos[content_set] = list(updated_package_names)
         result["last_change"] = page["last_change"]
-        if page["latest_repo_change"]:
+        if page.get("latest_repo_change"):
             ts = parser.parse(page["latest_repo_change"])
             if result["latest_repo_change"] is None or result["latest_repo_change"] < ts:
                 result["latest_repo_change"] = ts


### PR DESCRIPTION
Resiliency to avoid the following:
```

   File "/engine/vmaas_sync/vmaas_sync.py", line 256, in _fetch_vmaas_repos
     if page["latest_repo_change"]:
        ~~~~^^^^^^^^^^^^^^^^^^^^^^
 KeyError: 'latest_repo_change'
```

This state happen when there were no repositories (or they have lacked a sync).

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices

## Summary by Sourcery

Bug Fixes:
- Guard against missing 'latest_repo_change' key in API response to prevent KeyError